### PR TITLE
feat: add automatic retry with exponential backoff for retryable errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Retry with Exponential Backoff** (`src/kernel/executor.ts`) — automatic retry for retryable errors (rate limit, timeout, connection) using existing `ResilienceMiddleware.classifyError()` classification. Exponential backoff with jitter (`baseDelay * 2^attempt + 0-30% jitter`) prevents thundering herd. Base delays from resilience recommendations (rate limit: 5s, timeout: 2s, connection: 1s). Configurable via `KernelConfig.resilience.maxRetries` (default 2) and `retryBackoffMs` (default 1000ms). Permanent, auth, and user_action errors are never retried. Retry metadata (`retryAttempts`, `totalRetryDelayMs`) attached to responses.
+
 ### Changed
 - **README.md**: Full rewrite from 2,401 to ~360 lines targeting O&G investment professionals — removed ~1,200 lines of TypeScript code examples, aspirational features (Docker, WebSocket, SIEM), duplicate sections, and developer implementation guides; fixed factual errors (server counts, output paths, persona names, non-existent npm scripts)
 - **ARCHITECTURE.md**: Integrated kernel as main narrative instead of appendix — removed outdated "two-tier" / "6 agents" framing, duplicate "Composition — Abstraction Ladder" section, jest test examples, and aspirational Docker/Kubernetes deployment claims

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -76,6 +76,8 @@ export class Kernel {
 		this.executor = new Executor({
 			maxParallel: this.config.execution.maxParallel,
 			toolTimeoutMs: this.config.execution.toolTimeoutMs,
+			maxRetries: this.config.resilience.maxRetries,
+			retryBackoffMs: this.config.resilience.retryBackoffMs,
 		});
 		this.sessions = new SessionManager();
 		this.auth = new AuthMiddleware(this.config.security.requireAuth);

--- a/src/kernel/middleware/resilience.ts
+++ b/src/kernel/middleware/resilience.ts
@@ -258,7 +258,7 @@ export class ResilienceMiddleware {
 		}
 	}
 
-	private suggestRetryDelay(msg: string): number {
+	suggestRetryDelay(msg: string): number {
 		// Rate limit → longer delay
 		if (/rate.?limit|429|too many requests/i.test(msg)) return 5000;
 		// Timeout → moderate delay

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -133,6 +133,8 @@ export interface ResponseMetadata {
 	executionTimeMs: number;
 	idempotencyKey?: string;
 	timestamp: string;
+	retryAttempts?: number;
+	totalRetryDelayMs?: number;
 }
 
 /** Classified error with recovery guidance (Arcade: Recovery Guide pattern) */


### PR DESCRIPTION
Wire existing ResilienceMiddleware error classification to a retry loop in the Executor. Retryable errors (rate limit, timeout, connection) are automatically retried with exponential backoff and jitter to prevent thundering herd. Permanent, auth, and user_action errors are never retried. Configurable via KernelConfig.resilience.maxRetries (default 2) and retryBackoffMs (default 1000ms). Retry metadata (retryAttempts, totalRetryDelayMs) attached to responses.

## Summary

Brief description of the changes.

Fixes #(issue number)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] `npm run build` passes
- [ ] `npm run type-check` passes
- [ ] `npm run lint` passes
- [ ] `npm run test` passes
- [ ] `npm run demo` runs successfully
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated
