### PR TITLE
fix: eliminate TOCTOU race in e2e test (CodeQL #41)

### DIFF
--- a/tests/e2e-production.test.ts
+++ b/tests/e2e-production.test.ts
@@ -239,13 +239,12 @@ await test("npm run demo completes and produces INVESTMENT_DECISION.md", async (
 		// Timing: should complete in under 30 seconds
 		assert.ok(elapsed < 30_000, `Demo completed in ${elapsed}ms (must be < 30000ms)`);
 
-		// INVESTMENT_DECISION.md must exist
+		// INVESTMENT_DECISION.md must exist and contain the standard header.
+		// Read directly — if the file is missing, readFile throws a clear ENOENT error.
+		// This avoids a TOCTOU race between a stat() check and a subsequent read().
 		const decisionPath = path.join(outputDir, "INVESTMENT_DECISION.md");
-		const stat = await fs.stat(decisionPath);
-		assert.ok(stat.isFile() && stat.size > 0, "INVESTMENT_DECISION.md written and non-empty");
-
-		// Must contain the standard header
 		const content = await fs.readFile(decisionPath, "utf-8");
+		assert.ok(content.length > 0, "INVESTMENT_DECISION.md written and non-empty");
 		assert.ok(
 			content.includes("SHALE YEAH Investment Analysis Report"),
 			"INVESTMENT_DECISION.md contains standard report header",


### PR DESCRIPTION
## Summary

- Replaces `stat()` + `readFile()` two-step in `tests/e2e-production.test.ts:244` with a single `readFile()` call
- Eliminates the file-system race (CWE-367 / `js/file-system-race`) flagged by CodeQL as alert #41: the file could change or be removed between the `stat()` check and the subsequent `readFile()`
- Reading directly is race-free and simpler — `ENOENT` surfaces a clear error if the file is missing

## Test plan

- [x] `npx tsx tests/e2e-production.test.ts` — 13 passed, 0 failed, 2 skipped
- [x] `npm run lint` — clean

Fixes CodeQL alert [#41](https://github.com/ryemyster/ShaleYeah/security/code-scanning/41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)