### PR TITLE
feat: Token-Efficient Response — field projection and null stripping (#201)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Token-Efficient Response** (`src/kernel/middleware/output.ts`, `src/kernel/types.ts`) — Extends the existing Progressive Detail system with three new options on `OutputShaper.shape()`: `fields?: string[]` returns only the requested top-level fields (unknown fields silently ignored); `stripNulls?: boolean` recursively removes null/undefined fields while preserving falsy-but-valid values like `0` and `false`; `maxTokenHint?: number` records the caller's advisory token budget in response metadata (best-effort, not enforced). Field projection runs before null stripping so the two compose correctly. 7 new tests in `tests/kernel-output.test.ts`. (closes #201)
+
 - **Fallback Tool** (`src/kernel/registry.ts`, `src/kernel/executor.ts`, `src/kernel/types.ts`) — When a primary tool fails after all retries are exhausted, the kernel automatically routes to a registered fallback tool. Fallbacks are opt-in per tool via `registry.registerFallback(primaryTool, fallbackTool)`. Result metadata flags `usedFallback: true`, `originalTool`, and `fallbackTool` so callers always know when a substitute was used. Every fallback invocation is appended to `executor.getFallbackUsage()` (audit log) with the primary tool name, fallback tool name, failure reason, and timestamp. 14 tests in `tests/kernel-fallback.test.ts`. (closes #149)
 - **Biome bump** — `@biomejs/biome` updated from 2.4.9 to 2.4.11; `biome.json` schema URL updated to match.
 

--- a/src/kernel/middleware/output.ts
+++ b/src/kernel/middleware/output.ts
@@ -46,6 +46,11 @@ const STANDARD_STRIP_FIELDS: string[] = [
 export class OutputShaper {
 	/**
 	 * Shape a raw tool response into an AgentOSResponse with the requested detail level.
+	 *
+	 * Token-Efficient Response options (Arcade pattern — issue #201):
+	 *   fields      — only include these top-level keys in the response data
+	 *   maxTokenHint — advisory token budget; recorded in metadata, not enforced
+	 *   stripNulls  — when true, omit null/undefined fields (default: off)
 	 */
 	shape<T = unknown>(
 		rawData: T,
@@ -55,13 +60,30 @@ export class OutputShaper {
 			persona: string;
 			executionTimeMs: number;
 			confidence?: number;
+			/** Only include these top-level fields in the response payload. */
+			fields?: string[];
+			/** Advisory token budget — stored in metadata, not enforced. */
+			maxTokenHint?: number;
+			/** Strip null/undefined fields from the response payload. */
+			stripNulls?: boolean;
 		},
 	): AgentOSResponse<T> {
 		const level = options.detailLevel ?? "standard";
 		const confidence = options.confidence ?? this.extractConfidence(rawData) ?? 0;
 
 		const domain = this.detectDomain(rawData);
-		const shaped = this.applyDetailLevel(rawData, level, domain);
+		let shaped: unknown = this.applyDetailLevel(rawData, level, domain);
+
+		// Apply field projection before null stripping — projection narrows the object,
+		// stripping then cleans what remains. Order matters for the combined case.
+		if (options.fields && options.fields.length > 0) {
+			shaped = applyFieldProjection(shaped, options.fields);
+		}
+
+		if (options.stripNulls === true) {
+			shaped = applyNullStripping(shaped);
+		}
+
 		const summary = this.summarize(rawData, domain, confidence);
 
 		const metadata: ResponseMetadata = {
@@ -69,6 +91,7 @@ export class OutputShaper {
 			persona: options.persona,
 			executionTimeMs: options.executionTimeMs,
 			timestamp: new Date().toISOString(),
+			...(options.maxTokenHint !== undefined ? { maxTokenHint: options.maxTokenHint } : {}),
 		};
 
 		return {
@@ -300,6 +323,37 @@ export class OutputShaper {
 // ==========================================
 // Helpers
 // ==========================================
+
+// ==========================================
+// Token-Efficient Response helpers (Arcade: Token-Efficient Response — #201)
+// ==========================================
+
+/**
+ * Return only the requested top-level fields from the data object.
+ * Unknown field names are silently ignored — callers should not need to know the schema.
+ * Non-object data passes through unchanged.
+ */
+function applyFieldProjection(data: unknown, fields: string[]): unknown {
+	if (!fields.length || typeof data !== "object" || data === null) return data;
+	const obj = data as Record<string, unknown>;
+	return Object.fromEntries(fields.filter((f) => f in obj).map((f) => [f, obj[f]]));
+}
+
+/**
+ * Recursively remove null and undefined fields from an object.
+ * Preserves falsy-but-valid values like 0, false, and empty strings.
+ * Non-object data passes through unchanged.
+ */
+function applyNullStripping(data: unknown): unknown {
+	if (typeof data !== "object" || data === null) return data;
+	if (Array.isArray(data)) return data.map(applyNullStripping);
+	const obj = data as Record<string, unknown>;
+	return Object.fromEntries(
+		Object.entries(obj)
+			.filter(([, v]) => v !== null && v !== undefined)
+			.map(([k, v]) => [k, applyNullStripping(v)]),
+	);
+}
 
 function capitalize(s: string): string {
 	return s.charAt(0).toUpperCase() + s.slice(1);

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -150,6 +150,12 @@ export interface ResponseMetadata {
 	 * The fallback tool name that was actually executed (set when usedFallback is true).
 	 */
 	fallbackTool?: string;
+	/**
+	 * Advisory token budget passed by the caller (Arcade: Token-Efficient Response).
+	 * The shaper records this in metadata so callers can verify it was received.
+	 * Enforcement is best-effort — it does not truncate content.
+	 */
+	maxTokenHint?: number;
 }
 
 /**

--- a/tests/kernel-output.test.ts
+++ b/tests/kernel-output.test.ts
@@ -276,6 +276,86 @@ assert(overrideResp.confidence === 99, "Explicit confidence overrides extracted 
 // Summary
 // ==========================================
 
+// ==========================================
+// Test: Token-Efficient Response — field projection (fields?: string[])
+// ==========================================
+
+console.log("\n🎯 Testing field projection (fields option)...");
+const econProjected = shaper.shape(econData, { ...baseOpts, detailLevel: "full", fields: ["economic"] });
+const econProjData = econProjected.data as Record<string, unknown>;
+assert("economic" in econProjData, "Projected data includes requested field");
+assert(!("confidence" in econProjData), "Projected data excludes unrequested fields");
+
+const multiProjected = shaper.shape(econData, { ...baseOpts, detailLevel: "full", fields: ["economic", "confidence"] });
+const multiProjData = multiProjected.data as Record<string, unknown>;
+assert("economic" in multiProjData, "Multi-projection includes first field");
+assert("confidence" in multiProjData, "Multi-projection includes second field");
+
+// Unknown field names are silently ignored — no error
+const unknownProjected = shaper.shape(econData, { ...baseOpts, detailLevel: "full", fields: ["nonexistent"] });
+const unknownProjData = unknownProjected.data as Record<string, unknown>;
+assert(Object.keys(unknownProjData).length === 0, "Unknown field names produce empty object (no error)");
+
+// Empty fields array = no projection (return all)
+const emptyProjected = shaper.shape(econData, { ...baseOpts, detailLevel: "full", fields: [] });
+const emptyProjData = emptyProjected.data as Record<string, unknown>;
+assert("economic" in emptyProjData, "Empty fields array returns all fields");
+assert("confidence" in emptyProjData, "Empty fields array returns all fields (confidence present)");
+
+// ==========================================
+// Test: Token-Efficient Response — null stripping (stripNulls?: boolean)
+// ==========================================
+
+console.log("\n🧹 Testing null stripping (stripNulls option)...");
+const dataWithNulls = { a: 1, b: null, c: undefined, d: "value", e: 0 };
+const stripped = shaper.shape(dataWithNulls, { ...baseOpts, detailLevel: "full", stripNulls: true });
+const strippedData = stripped.data as Record<string, unknown>;
+assert("a" in strippedData, "stripNulls keeps non-null fields (a)");
+assert("d" in strippedData, "stripNulls keeps string fields (d)");
+assert("e" in strippedData, "stripNulls keeps falsy-but-non-null fields (0)");
+assert(!("b" in strippedData), "stripNulls removes null fields");
+assert(!("c" in strippedData), "stripNulls removes undefined fields");
+
+// stripNulls: false — preserve nulls
+const notStripped = shaper.shape(dataWithNulls, { ...baseOpts, detailLevel: "full", stripNulls: false });
+const notStrippedData = notStripped.data as Record<string, unknown>;
+assert("b" in notStrippedData, "stripNulls:false preserves null fields");
+
+// Default behavior (no stripNulls specified) preserves existing behavior — no stripping
+const defaultStrip = shaper.shape(dataWithNulls, { ...baseOpts, detailLevel: "full" });
+const defaultStripData = defaultStrip.data as Record<string, unknown>;
+assert("b" in defaultStripData, "Default (no stripNulls) preserves null fields");
+
+// ==========================================
+// Test: maxTokenHint is stored in metadata
+// ==========================================
+
+console.log("\n📏 Testing maxTokenHint passthrough...");
+const hintResp = shaper.shape(econData, { ...baseOpts, detailLevel: "full", maxTokenHint: 500 });
+assert((hintResp.metadata as Record<string, unknown>).maxTokenHint === 500, "maxTokenHint stored in metadata");
+
+const noHintResp = shaper.shape(econData, { ...baseOpts, detailLevel: "full" });
+assert(
+	(noHintResp.metadata as Record<string, unknown>).maxTokenHint === undefined,
+	"maxTokenHint absent when not specified",
+);
+
+// ==========================================
+// Test: fields + stripNulls combined
+// ==========================================
+
+console.log("\n🔗 Testing fields + stripNulls combined...");
+const combined = shaper.shape(
+	{ economic: { npv: 1000, irr: null }, confidence: 80 },
+	{ ...baseOpts, detailLevel: "full", fields: ["economic"], stripNulls: true },
+);
+const combinedData = combined.data as Record<string, unknown>;
+assert("economic" in combinedData, "Combined: projected field present");
+assert(!("confidence" in combinedData), "Combined: non-projected field absent");
+const combinedEcon = combinedData.economic as Record<string, unknown>;
+assert("npv" in combinedEcon, "Combined: non-null sub-field present");
+assert(!("irr" in combinedEcon), "Combined: null sub-field stripped");
+
 console.log(`\n${"=".repeat(70)}`);
 console.log("📊 KERNEL OUTPUT SHAPING TEST SUMMARY");
 console.log("=".repeat(70));


### PR DESCRIPTION
## Summary

- Extends `OutputShaper.shape()` with `fields`, `stripNulls`, and `maxTokenHint` options (Arcade: Token-Efficient Response pattern)
- `fields?: string[]` — return only requested top-level keys; unknown field names silently ignored
- `stripNulls?: boolean` — recursively remove null/undefined fields; preserves falsy-but-valid values (`0`, `false`, `""`)
- `maxTokenHint?: number` — advisory token budget recorded in `ResponseMetadata`; best-effort, not enforced
- Field projection runs before null stripping so both options compose correctly
- `ResponseMetadata` gains `maxTokenHint?` field
- 7 new tests; all 76 output tests pass; full suite and demo pass

## Test plan

- [ ] `npx tsx tests/kernel-output.test.ts` — 76 tests, 0 failures
- [ ] `npm run build && npm run type-check && npm run lint` — clean
- [ ] `npm run test` — full suite passes
- [ ] `npm run demo` — 14-server smoke test passes

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)