### PR TITLE
chore: consolidate anti-pattern greps and research constraints (#307)

### DIFF
--- a/.claude/skills/code-review.md
+++ b/.claude/skills/code-review.md
@@ -33,24 +33,7 @@ These are scope creep candidates — they need explicit justification or should 
 
 ### 3. Anti-pattern scan
 
-Run each grep. A result here is a violation — report it and stop the review as failed.
-
-Rules and exceptions are defined in `CLAUDE.md ## Standards`. These greps enforce them:
-
-```bash
-# Rule: no direct Anthropic SDK imports in server files (see CLAUDE.md ## Standards)
-grep -rn "from '@anthropic-ai/sdk'\|from \"@anthropic-ai/sdk\"" src/servers/ 2>/dev/null
-
-# Rule: no Math.random() in business logic — exception: named Monte Carlo samplers in risk-analysis.ts (see CLAUDE.md ## Standards)
-grep -rn "Math\.random()" src/servers/ src/kernel/ 2>/dev/null | grep -v "sampleUniform\|sampleTriangular\|sampleNormal\|function sample"
-
-# Rule: no z.any() in Zod schemas — exception: mcp-server.ts and server-factory.ts (see CLAUDE.md ## Standards)
-grep -rn "z\.any()" src/servers/ 2>/dev/null
-
-# Warning: ?.field || 0 silent defaults hide missing upstream data (see CLAUDE.md ## Standards)
-grep -rn "?\..*|| 0\|?\..*|| \"\"\|?\..*|| \[\]" src/servers/ src/kernel/ 2>/dev/null | grep -v "test" | grep -v "node_modules"
-```
-
+Run the same greps as `/pre-commit` step 1 — rules and exceptions are defined there (single source of truth).
 If any grep returns results, list the file:line and explain why it violates the rule.
 
 ### 4. Ghost-close guard

--- a/.claude/skills/research.md
+++ b/.claude/skills/research.md
@@ -26,12 +26,7 @@ output should be grounded in this context:
 
 See [`docs/SERVERS.md`](../../docs/SERVERS.md) for the full server and tool reference — domains, personas, LLM status, key data needs, and industry standards (LAS/DLIS, WITSML, OSDU, PPDM, ARIES, Volve, EIA, FracFocus).
 
-**Architectural constraints:**
-- All LLM calls go through `src/shared/llm-client.ts` (no direct SDK calls in servers)
-- Integrations must be config-driven (`integrations.config.json`) and pluggable
-- CI has no API key — integrations must have free-tier or mock support
-- TypeScript strict mode — every integration needs a typed adapter interface
-- Code quality rules (no `Math.random()`, no `z.any()`, no silent defaults, etc.) are defined in `CLAUDE.md ## Standards`
+**Architectural constraints:** All LLM calls via `src/shared/llm-client.ts`. Integrations config-driven (`integrations.config.json`), CI-safe (mock or free-tier), TypeScript strict. Code quality rules in `CLAUDE.md ## Standards`.
 
 ---
 


### PR DESCRIPTION
## Summary
- `code-review.md` step 3 now delegates to `/pre-commit` as single source of truth for anti-pattern greps — eliminates duplicated grep commands that had drifted slightly from the canonical versions
- `research.md` architectural constraints block collapsed from 5 bullets to 1 line pointing at `CLAUDE.md ## Standards`

## Part of
#307 — Skills & Prompt System Audit (pending items from previous session)

## Test plan
- [ ] No TypeScript changes — build/type-check/lint all pass (verified)
- [ ] Manually confirm `code-review.md` step 3 still instructs running anti-pattern checks (via pre-commit reference)
- [ ] Manually confirm `research.md` still has full domain context via pointer to `docs/SERVERS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)