### PR TITLE
feat(quality-assurance): add Tier 2 QA agent package (#376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Quality Assurance agent** (`agents/quality-assurance/`) (#376) — new Tier 2 agent wrapping the `@shaleyeah/server-qa` MCP server via `StreamableHTTPClientTransport`. Exports `qaAssuranceManifest`, `qaAssuranceConfig`, `createQAAssuranceRuntime()`, `createQAAssuranceEndpoint()`, and `callQAServerTool()`. Manifests 2 QA tools (`quality-assurance.run_quality_tests`, `quality-assurance.generate_quality_report`) with model capability requirements (`standard-analysis`, `deterministic`), `read:qa` scopes, eval profiles, and HITL config. Follows the exact geologist agent pattern. 42 tests pass (5 MCP-client + 37 contract). (closes #376)
+
 ### Changed
 
 - **Monorepo conversion (#385)** — Restructured from a single npm package to a pnpm workspace with Turborepo. `src/` and `tools/` deleted; all code lives in packages: `sdk/` (shared language), `servers/*/` (14 Tier 1 MCP servers), `agents/*/` (14 Tier 2 agent packages — geologist and agent-zero fully implemented, 12 stubs), `orchestrator/` (stub, Temporal workflows deferred to #362). Kernel deleted (retired Arcade.dev pattern). `biome.json` moved to per-package. CI updated to pnpm + Turborepo. `pnpm demo` proves the geologist agent boots standalone. Dead-code greps return zero. (closes #385)

--- a/agents/quality-assurance/CHANGELOG.md
+++ b/agents/quality-assurance/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog — @shaleyeah/quality-assurance
+
+## [Unreleased]
+
+### Added
+- **Initial package** (#376) — quality-assurance Tier 2 agent wrapping `@shaleyeah/server-qa` over MCP HTTP transport. Exports `qaAssuranceManifest`, `qaAssuranceConfig`, `createQAAssuranceRuntime()`, `createQAAssuranceEndpoint()`, and `callQAServerTool()`. Manifests 2 QA tools (`quality-assurance.run_quality_tests`, `quality-assurance.generate_quality_report`) with explicit model capability requirements, scopes, input schemas, and eval profiles. All tool handlers connect to qa-server via `StreamableHTTPClientTransport` at the URL in `AgentRuntimeConfig.mcpServers["qa-server"].url` (defaults to `http://localhost:3004`).
+
+### Tests
+- `tests/mcp-client.test.ts` — verifies `callQAServerTool` export, config wiring (URL, transport), all tools declare `mcpServer: "qa-server"`, and error propagation when qa-server is unreachable. Integration test for live MCP round-trip is skipped when qa-server is not running.
+- `tests/agent.test.ts` — 37 contract tests covering manifest validation, progressive discovery, organization-owned model routing, HITL policy, evals, standalone boot, and invalid manifest rejection.

--- a/agents/quality-assurance/README.md
+++ b/agents/quality-assurance/README.md
@@ -1,0 +1,24 @@
+# @shaleyeah/quality-assurance
+
+Testius Validatus — the ShaleYeah fleet's quality assurance agent.
+
+Tier 2 intelligence layer: wraps the Tier 1 qa-server MCP server's tools with agent-level reasoning, eval framework, and HITL controls.
+
+## Quick start
+
+```bash
+pnpm start   # runs the agent's standalone runtime
+```
+
+## Building
+
+```bash
+pnpm build
+pnpm test    # 42 tests
+```
+
+## Environment
+
+| Variable | Purpose |
+|----------|---------|
+| `ANTHROPIC_API_KEY` | Required for synthesis calls |

--- a/agents/quality-assurance/biome.json
+++ b/agents/quality-assurance/biome.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
+	"formatter": { "enabled": true, "indentStyle": "tab", "indentWidth": 2, "lineWidth": 120 },
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"suspicious": {
+				"noExplicitAny": "off",
+				"noAssignInExpressions": "off",
+				"useIterableCallbackReturn": "off",
+				"noControlCharactersInRegex": "off"
+			},
+			"style": { "noNonNullAssertion": "off" },
+			"complexity": { "noStaticOnlyClass": "off", "noUselessLoneBlockStatements": "off" }
+		}
+	},
+	"files": { "includes": ["src/**", "tests/**/*.ts", "*.json", "*.ts"] }
+}

--- a/agents/quality-assurance/docs/ARCHITECTURE.md
+++ b/agents/quality-assurance/docs/ARCHITECTURE.md
@@ -1,0 +1,77 @@
+# Architecture — @shaleyeah/quality-assurance
+
+## Role
+
+Tier 2 agent. Wraps the `@shaleyeah/server-qa` tool layer with agent-level intelligence: scope enforcement, model routing, HITL policy, eval scoring, and memory. The quality-assurance agent exposes the same 2 QA tools as qa-server, but with agent contracts enforced on top.
+
+## Tool inventory
+
+| Tool | Model requirement | HITL? | Eval profile |
+|------|------------------|-------|-------------|
+| `quality-assurance.run_quality_tests` | `standard-analysis` | No | `qa-run-tests` |
+| `quality-assurance.generate_quality_report` | `deterministic` | No | `qa-generate-report` |
+
+All tools require `read:qa` scope. None are destructive or require human approval — the quality-assurance agent only reads and validates data.
+
+## How it differs from @shaleyeah/server-qa
+
+The qa-server and the quality-assurance agent expose the same underlying functions, but at different layers:
+
+| Concern | server-qa (Tier 1) | quality-assurance (Tier 2) |
+|---------|-------------------|---------------------------|
+| Transport | MCP over stdio | AgentRuntime (no transport) |
+| Routing | None — receives tool calls | Routes to `standard-analysis` or `deterministic` model |
+| HITL | None | Configured (currently off for all tools; can be enabled per tool) |
+| Evals | None | Schema validation, secret redaction, confidence scoring |
+| Memory | None | `@shaleyeah/sdk` memory layer (disabled by default) |
+| Scopes | None | `read:qa` required on all calls |
+| Autonomy | Always executes | `"reviewed"` — can be changed to `"assistive"` or `"autonomous"` |
+
+## Execution path
+
+```
+quality-assurance.run_quality_tests { targets, testSuite }
+  → AgentRuntime.execute()
+    → scope check: "read:qa" required
+    → handler: callQAServerTool() → qa-server over StreamableHTTPClientTransport
+      (URL from AgentRuntimeConfig.mcpServers["qa-server"].url)
+    → eval: schema + redactSecrets
+    → AgentToolResult { status, data, evals, metadata }
+```
+
+## HITL policy (qaAssuranceConfig)
+
+```
+approvalMode: "when-sensitive"    — human review triggered on high-risk calls
+requireForDestructive: true       — none of quality-assurance's tools are destructive
+requireForMemoryPromotion: true   — any memory write requires review
+```
+
+## Model routing
+
+```
+"standard-analysis" → configured by operator (for QA synthesis and validation)
+"deterministic"     → rule-based: no LLM call (report generation)
+```
+
+No provider names are hardcoded — the operator configures which models map to these capability labels via `AgentRuntimeConfig.modelRouting`.
+
+## Memory policy
+
+```
+enabled: true              — memory system is wired
+namespace: "quality-assurance"
+vectorStore.enabled: false — vector memory off until a store is configured
+retentionDays: 90
+promotion.requireHumanReview: true
+```
+
+## Dependencies
+
+```
+@shaleyeah/quality-assurance
+  ├── @shaleyeah/sdk                  (AgentManifest, AgentRuntime, contracts)
+  └── @modelcontextprotocol/sdk       (StreamableHTTPClientTransport)
+```
+
+The quality-assurance agent does NOT depend on the orchestrator or any other agent. It can be deployed and tested in complete isolation from the rest of the fleet.

--- a/agents/quality-assurance/docs/DEPLOYMENT.md
+++ b/agents/quality-assurance/docs/DEPLOYMENT.md
@@ -1,0 +1,24 @@
+# Deployment — @shaleyeah/quality-assurance
+
+## Standalone
+
+```bash
+pnpm build
+pnpm start
+```
+
+## Environment variables
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `ANTHROPIC_API_KEY` | Yes | LLM synthesis |
+
+## qa-server dependency
+
+The agent connects to `@shaleyeah/server-qa` over HTTP. Start qa-server before the agent:
+
+```bash
+PORT=3004 cd servers/qa-server && pnpm start
+```
+
+The URL defaults to `http://localhost:3004` and can be overridden by providing a custom `AgentRuntimeConfig` with `mcpServers["qa-server"].url` set to your deployment address.

--- a/agents/quality-assurance/package.json
+++ b/agents/quality-assurance/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "@shaleyeah/quality-assurance",
+	"version": "0.1.0",
+	"description": "Quality Assurance agent — Tier 2 intelligence layer for QA validation and reporting",
+	"private": true,
+	"type": "module",
+	"main": "dist/agent/index.js",
+	"scripts": {
+		"build": "tsc",
+		"start": "tsx src/agent/index.ts",
+		"test": "bash ../../scripts/run-tests.sh",
+		"lint": "biome check .",
+		"type-check": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@modelcontextprotocol/sdk": "^1.29.0",
+		"@shaleyeah/sdk": "workspace:*"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.11",
+		"@types/node": "^25.6.0",
+		"tsx": "^4.21.0",
+		"typescript": "^6.0.2"
+	}
+}

--- a/agents/quality-assurance/src/agent/index.ts
+++ b/agents/quality-assurance/src/agent/index.ts
@@ -1,0 +1,226 @@
+import type { AgentManifest, AgentRuntimeConfig } from "@shaleyeah/sdk";
+import { LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import { callQAServerTool } from "./qa-server-client.js";
+
+export { callQAServerTool };
+
+export const qaAssuranceManifest: AgentManifest = {
+	id: "quality-assurance",
+	role: "qa-analyst",
+	version: "0.1.0",
+	description:
+		"Testius Validatus — standalone quality assurance agent migrated from the qa-server MCP server onto the AgentRuntime contract.",
+	persona: {
+		name: "Testius Validatus",
+		role: "Master Quality Engineer",
+		expertise: [
+			"Quality assurance and validation",
+			"Testing methodology and automation",
+			"Performance monitoring and analysis",
+			"Compliance verification and auditing",
+			"Continuous improvement processes",
+		],
+	},
+	capabilities: [
+		"qa-testing",
+		"quality-reporting",
+		"compliance-verification",
+		"performance-monitoring",
+		"model-routing",
+		"evals",
+	],
+	tools: [
+		{
+			name: "quality-assurance.run_quality_tests",
+			description:
+				"Execute comprehensive quality assurance tests across functional, performance, integration, and compliance dimensions.",
+			type: "query",
+			capabilities: ["qa-testing", "compliance-verification"],
+			inputSchema: {
+				type: "object",
+				properties: {
+					testSuite: {
+						type: "string",
+						enum: ["functional", "performance", "integration", "compliance", "all"],
+						default: "all",
+						description: "Test suite to run",
+					},
+					targets: {
+						type: "array",
+						items: { type: "string" },
+						description: "Components or modules to test",
+					},
+					criteria: {
+						type: "object",
+						properties: {
+							accuracy: { type: "number", minimum: 0, maximum: 1, default: 0.95 },
+							performance: { type: "string", default: "standard" },
+							compliance: { type: "array", items: { type: "string" }, default: [] },
+						},
+					},
+					outputPath: { type: "string", description: "Optional path to write JSON output" },
+				},
+				required: ["targets"],
+			},
+			readOnly: false,
+			destructive: false,
+			requiresHumanApproval: false,
+			requiredScopes: ["read:qa"],
+			modelRequirement: "standard-analysis",
+			evalProfile: "qa-run-tests",
+			mcpServer: "qa-server",
+		},
+		{
+			name: "quality-assurance.generate_quality_report",
+			description:
+				"Generate a comprehensive quality assurance report covering accuracy, performance, and reliability metrics.",
+			type: "query",
+			capabilities: ["quality-reporting", "compliance-verification"],
+			inputSchema: {
+				type: "object",
+				properties: {
+					reportType: {
+						type: "string",
+						enum: ["summary", "detailed", "executive", "compliance"],
+						default: "summary",
+						description: "Report format",
+					},
+					period: { type: "string", default: "current", description: "Reporting period" },
+					metrics: {
+						type: "array",
+						items: { type: "string" },
+						default: ["accuracy", "performance", "reliability"],
+						description: "Metrics to include",
+					},
+					outputPath: { type: "string", description: "Optional path to write JSON output" },
+				},
+				required: [],
+			},
+			readOnly: true,
+			destructive: false,
+			requiresHumanApproval: false,
+			requiredScopes: ["read:qa"],
+			modelRequirement: "deterministic",
+			evalProfile: "qa-generate-report",
+			mcpServer: "qa-server",
+		},
+	],
+	requiredScopes: ["read:qa"],
+	providerRequirements: [
+		{
+			type: "llm",
+			required: true,
+			description:
+				"Organization-selected LLM for QA synthesis — test validation and compliance assessment call the model.",
+		},
+	],
+	compatibility: {
+		agentRuntime: "0.1",
+		remoteEndpoint: "0.1",
+		mcp: "2025-06",
+	},
+	health: {
+		readinessChecks: ["manifest", "runtime-config", "tool-handlers", "model-routing"],
+	},
+	memory: {
+		namespace: "quality-assurance",
+		reviewRequired: true,
+		sharedMemoryOptIn: false,
+	},
+	evals: {
+		defaultProfile: "qa-standard",
+		requiredChecks: ["schema", "redactSecrets"],
+	},
+	autonomy: {
+		defaultLevel: "reviewed",
+		allowedLevels: ["assistive", "reviewed", "autonomous"],
+	},
+};
+
+export const qaAssuranceConfig: AgentRuntimeConfig = {
+	autonomy: "reviewed",
+	modelRouting: {
+		"small-fast": {
+			provider: "organization-small-model",
+			model: "configured-by-operator",
+		},
+		"standard-analysis": {
+			provider: "organization-standard-model",
+			model: "configured-by-operator",
+		},
+		"deep-reasoning": {
+			provider: "organization-deep-model",
+			model: "configured-by-operator",
+		},
+		"local-private": {
+			provider: "organization-local-model",
+			model: "configured-by-operator",
+		},
+		deterministic: {
+			provider: "rule-based",
+			model: "no-model",
+		},
+	},
+	hitl: {
+		approvalMode: "when-sensitive",
+		requireForDestructive: true,
+		requireForMemoryPromotion: true,
+	},
+	evals: {
+		enabled: true,
+		profile: "qa-standard",
+		checks: {
+			schema: "blocking",
+			domainCompleteness: "advisory",
+			confidenceMinimum: 0.7,
+			requireSources: false,
+			redactSecrets: "blocking",
+			memoryPromotion: "reviewed-only",
+		},
+	},
+	memory: {
+		enabled: true,
+		namespace: "quality-assurance",
+		vectorStore: { enabled: false },
+		retentionDays: 90,
+		promotion: {
+			requireHumanReview: true,
+			allowSharedMemory: false,
+		},
+	},
+	// Tier 1 tool server — operator configures the actual URL at deployment time.
+	mcpServers: {
+		"qa-server": {
+			url: "http://localhost:3004",
+			transport: "http",
+			authType: "none",
+		},
+	},
+	dataConnectors: {},
+};
+
+// Each handler resolves the qa-server URL from the runtime config and delegates via MCP over HTTP.
+// The server name "qa-server" matches AgentToolManifest.mcpServer and AgentRuntimeConfig.mcpServers key.
+function qaServerUrl(config: AgentRuntimeConfig): string {
+	return config.mcpServers?.["qa-server"]?.url ?? "http://localhost:3004";
+}
+
+const handlers: Record<string, StandaloneToolHandler> = {
+	"quality-assurance.run_quality_tests": ({ args, config }) =>
+		callQAServerTool(qaServerUrl(config), "run_quality_tests", args),
+
+	"quality-assurance.generate_quality_report": ({ args, config }) =>
+		callQAServerTool(qaServerUrl(config), "generate_quality_report", args),
+};
+
+export function createQAAssuranceRuntime(config: AgentRuntimeConfig = qaAssuranceConfig): LocalAgentRuntime {
+	return new LocalAgentRuntime({
+		manifest: qaAssuranceManifest,
+		config,
+		handlers,
+	});
+}
+
+export function createQAAssuranceEndpoint(config: AgentRuntimeConfig = qaAssuranceConfig): LocalAgentEndpoint {
+	return new LocalAgentEndpoint(createQAAssuranceRuntime(config));
+}

--- a/agents/quality-assurance/src/agent/qa-server-client.ts
+++ b/agents/quality-assurance/src/agent/qa-server-client.ts
@@ -1,0 +1,26 @@
+/**
+ * QA Server MCP client — thin wrapper that connects to the qa-server Tier 1 server over HTTP,
+ * calls a single tool, and closes the connection.
+ *
+ * One-shot per call: simpler than managing a persistent connection for a standalone agent
+ * that may not run co-located with qa-server at all times.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+/**
+ * Call a tool on the qa-server MCP server at `url` and return its result content.
+ * Throws if the server is unreachable or the tool call fails.
+ */
+export async function callQAServerTool(url: string, toolName: string, args: Record<string, unknown>): Promise<unknown> {
+	const transport = new StreamableHTTPClientTransport(new URL(url));
+	const client = new Client({ name: "quality-assurance", version: "0.1.0" });
+	await client.connect(transport);
+	try {
+		const result = await client.callTool({ name: toolName, arguments: args });
+		return result.content;
+	} finally {
+		await client.close();
+	}
+}

--- a/agents/quality-assurance/tests/agent.test.ts
+++ b/agents/quality-assurance/tests/agent.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Quality Assurance Agent Contract Tests — Issue #376
+ *
+ * Proves the qa-server tools are accessible through the AgentRuntime contract
+ * and that the quality-assurance manifest satisfies all Arcade acceptance criteria.
+ */
+
+import { AgentManifestSchema, AgentRuntimeConfigSchema, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	createQAAssuranceEndpoint,
+	createQAAssuranceRuntime,
+	qaAssuranceConfig,
+	qaAssuranceManifest,
+} from "../src/agent/index.js";
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, message: string): void {
+	if (condition) {
+		console.log(`  ✅ ${message}`);
+		passed++;
+	} else {
+		console.error(`  ❌ ${message}`);
+		failed++;
+	}
+}
+
+console.log("🧪 Starting Quality Assurance Agent Contract Tests (#376)\n");
+
+console.log("📋 Testing manifest and config validation...");
+{
+	const manifest = AgentManifestSchema.safeParse(qaAssuranceManifest);
+	assert(manifest.success, "Quality-assurance manifest validates");
+	if (!manifest.success) console.error("  ", manifest.error.format());
+
+	const config = AgentRuntimeConfigSchema.safeParse(qaAssuranceConfig);
+	assert(config.success, "Quality-assurance runtime config validates");
+
+	assert(qaAssuranceManifest.tools.length === 2, "Quality-assurance exposes 2 QA tools");
+	assert(
+		qaAssuranceManifest.tools.every((t) => t.name.startsWith("quality-assurance.")),
+		"All tools follow quality-assurance. naming convention",
+	);
+	assert(
+		qaAssuranceManifest.tools.every((t) => !t.modelRequirement.includes("claude")),
+		"Model requirements are capability labels, not provider names",
+	);
+	// Manifest-level scopes must cover all tool-level scopes (enforced by refine in schema)
+	const allToolScopes = new Set(qaAssuranceManifest.tools.flatMap((t) => t.requiredScopes));
+	assert(
+		[...allToolScopes].every((s) => qaAssuranceManifest.requiredScopes.includes(s)),
+		"Manifest requiredScopes is a superset of all tool requiredScopes",
+	);
+	// LLM provider is marked required — quality-assurance actively calls the model
+	const llmReq = qaAssuranceManifest.providerRequirements.find((p) => p.type === "llm");
+	assert(llmReq?.required === true, "LLM provider requirement is marked required");
+}
+
+console.log("\n🔎 Testing progressive discovery...");
+{
+	const runtime = createQAAssuranceRuntime();
+	await runtime.initialize();
+
+	const summary = runtime.discover("summary");
+	assert("capabilities" in summary, "Summary discovery returns capabilities");
+	assert(!("tools" in summary), "Summary discovery does not include tool list");
+
+	const tools = runtime.discover("tools");
+	assert(Array.isArray(tools) && tools.length === 2, "Tool discovery returns 2 tools");
+	assert(!("inputSchema" in tools[0]), "Tool list omits input schemas");
+
+	const schema = runtime.discover("schema", "quality-assurance.run_quality_tests");
+	assert(schema?.inputSchema !== undefined, "Schema discovery returns run_quality_tests input schema");
+	assert(
+		(schema?.inputSchema as Record<string, unknown>)?.required !== undefined,
+		"run_quality_tests schema declares required fields",
+	);
+
+	const missing = runtime.discover("schema", "quality-assurance.nonexistent");
+	assert(missing === null, "Schema discovery returns null for unknown tool");
+
+	await runtime.shutdown();
+}
+
+console.log("\n🧭 Testing organization-owned model routing...");
+{
+	// Handlers call qa-server over MCP — execution tests require a live server.
+	// Verify routing contracts at the config level without executing through the network.
+	const customRouting = {
+		...qaAssuranceConfig.modelRouting,
+		"standard-analysis": {
+			provider: "acme-qa-llm",
+			model: "operator-selected-model",
+		},
+	};
+
+	const reportTool = qaAssuranceManifest.tools.find((t) => t.name === "quality-assurance.run_quality_tests");
+	assert(reportTool !== undefined, "run_quality_tests tool is declared in manifest");
+
+	const deterministicRoute = qaAssuranceConfig.modelRouting.deterministic;
+	assert(deterministicRoute !== undefined, "Deterministic route is configured");
+	assert(deterministicRoute.provider === "rule-based", "Deterministic tools use rule-based provider");
+
+	// Verify operator override wires correctly into the config shape
+	const overrideRoute = customRouting["standard-analysis"];
+	assert(overrideRoute.provider === "acme-qa-llm", "Operator override populates provider");
+	assert(overrideRoute.model === "operator-selected-model", "Operator override populates model");
+}
+
+console.log("\n📡 Testing model capability routing across requirement classes...");
+{
+	const runtime = createQAAssuranceRuntime();
+	await runtime.initialize();
+
+	const modelRequirements = new Set(qaAssuranceManifest.tools.map((t) => t.modelRequirement));
+	assert(modelRequirements.size > 0, "At least one model requirement class is declared");
+
+	for (const req of modelRequirements) {
+		const binding = qaAssuranceConfig.modelRouting[req];
+		assert(binding !== undefined, `Model route exists for requirement: ${req}`);
+	}
+
+	await runtime.shutdown();
+}
+
+console.log("\n🙋 Testing HITL policy wires through to config...");
+{
+	// No tool has requiresHumanApproval: true — verify at manifest level without executing
+	const approvalRequired = qaAssuranceManifest.tools.filter((t) => t.requiresHumanApproval);
+	assert(approvalRequired.length === 0, "No quality-assurance tool requires human approval by default");
+
+	// approvalMode: "always" forces a challenge before the handler is called — no live server needed
+	const strictRuntime = createQAAssuranceRuntime({
+		...qaAssuranceConfig,
+		hitl: { ...qaAssuranceConfig.hitl, approvalMode: "always" },
+	});
+	await strictRuntime.initialize();
+	const blocked = await strictRuntime.execute({
+		toolName: "quality-assurance.run_quality_tests",
+		args: { targets: ["test-component"] },
+	});
+	assert(blocked.status === "approval_required", "approvalMode: 'always' blocks all tools");
+	if (blocked.status === "approval_required") {
+		assert(blocked.challenge.type === "human_approval_required", "Challenge is structured");
+		assert(blocked.challenge.agentId === "quality-assurance", "Challenge identifies quality-assurance agent");
+	}
+
+	await strictRuntime.shutdown();
+}
+
+console.log("\n🧪 Testing evals policy is configured correctly...");
+{
+	// Handlers delegate to qa-server over MCP — execution-level eval tests require a live server.
+	// Verify the eval policy is correctly wired in config.
+	assert(qaAssuranceConfig.evals.enabled === true, "Evals are enabled");
+	assert(qaAssuranceConfig.evals.checks.schema === "blocking", "Schema eval is blocking");
+	assert(qaAssuranceConfig.evals.checks.redactSecrets === "blocking", "Secret-redaction eval is blocking");
+
+	// Verify eval profiles are declared on tools that need them
+	const profileTools = qaAssuranceManifest.tools.filter((t) => t.evalProfile);
+	assert(profileTools.length > 0, "At least one tool declares an eval profile");
+	assert(
+		profileTools.every((t) => typeof t.evalProfile === "string"),
+		"All declared eval profiles are strings",
+	);
+}
+
+console.log("\n🏥 Testing health endpoint and standalone boot...");
+{
+	const endpoint = createQAAssuranceEndpoint();
+	// Quality-assurance boots without kernel, orchestrator, or other agents present
+	const health = await endpoint.health();
+	assert(health.agentId === "quality-assurance", "Health endpoint identifies quality-assurance");
+	assert(health.status !== "not_ready", "Quality-assurance boots without external dependencies");
+
+	const manifest = await endpoint.manifest();
+	assert(manifest.id === "quality-assurance", "Endpoint exposes quality-assurance manifest");
+	assert(manifest.tools.length === 2, "Endpoint manifest has 2 tools");
+
+	const toolSchema = await endpoint.discoveryToolSchema("quality-assurance.run_quality_tests");
+	assert(toolSchema !== null, "Endpoint exposes tool schemas by name");
+}
+
+console.log("\n🛑 Testing invalid manifest fails early...");
+{
+	try {
+		new LocalAgentRuntime({
+			manifest: { ...qaAssuranceManifest, id: "" } as typeof qaAssuranceManifest,
+			config: qaAssuranceConfig,
+			handlers: Object.fromEntries(qaAssuranceManifest.tools.map((t) => [t.name, async () => ({})])),
+		});
+		assert(false, "Empty manifest id should fail validation");
+	} catch {
+		assert(true, "Invalid manifest id fails at construction");
+	}
+}
+
+console.log("\n══════════════════════════════════════════════");
+console.log(`Quality Assurance Agent Contract Tests: ${passed} passed, ${failed} failed`);
+console.log("══════════════════════════════════════════════");
+
+if (failed > 0) {
+	process.exit(1);
+}

--- a/agents/quality-assurance/tests/mcp-client.test.ts
+++ b/agents/quality-assurance/tests/mcp-client.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Quality Assurance MCP Client Tests — Issue #376
+ *
+ * Verifies the qa-server MCP client helper:
+ * - `callQAServerTool` is exported from the agent module
+ * - It reads the qa-server URL from AgentRuntimeConfig.mcpServers["qa-server"].url
+ * - The qaAssuranceConfig.mcpServers["qa-server"] entry points to localhost:3004
+ * - Transport is "http"
+ * - All agent tools declare mcpServer: "qa-server"
+ *
+ * Written before implementation (TDD — these fail until qa-server-client.ts and
+ * updated index.ts are in place).
+ *
+ * Integration tests that require a live qa-server are skipped when the server
+ * is not reachable — labelled "[integration]" for CI separation.
+ */
+
+import assert from "node:assert";
+import { callQAServerTool, qaAssuranceConfig, qaAssuranceManifest } from "../src/agent/index.js";
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void | Promise<void>): Promise<void> {
+	return Promise.resolve()
+		.then(fn)
+		.then(() => {
+			console.log(`  ✓ ${name}`);
+			passed++;
+		})
+		.catch((err: unknown) => {
+			console.log(`  ✗ ${name}`);
+			console.log(`    ${err instanceof Error ? err.message : String(err)}`);
+			failed++;
+		});
+}
+
+async function qaServerReachable(): Promise<boolean> {
+	try {
+		const url = qaAssuranceConfig.mcpServers?.["qa-server"]?.url ?? "http://localhost:3004";
+		const ctrl = new AbortController();
+		const timer = setTimeout(() => ctrl.abort(), 500);
+		await fetch(url, { method: "HEAD", signal: ctrl.signal });
+		clearTimeout(timer);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function runTests(): Promise<void> {
+	console.log("\n🧪 Quality Assurance MCP Client Tests (#376)\n");
+
+	await test("callQAServerTool is exported as a function", () => {
+		assert.strictEqual(typeof callQAServerTool, "function", "callQAServerTool must be exported");
+	});
+
+	await test('qaAssuranceConfig.mcpServers["qa-server"].url is http://localhost:3004', () => {
+		const conn = qaAssuranceConfig.mcpServers?.["qa-server"];
+		assert.ok(conn, 'mcpServers["qa-server"] entry must be present');
+		assert.strictEqual(conn.url, "http://localhost:3004", "qa-server URL is localhost:3004");
+	});
+
+	await test('qaAssuranceConfig.mcpServers["qa-server"].transport is http', () => {
+		const conn = qaAssuranceConfig.mcpServers?.["qa-server"];
+		assert.ok(conn, 'mcpServers["qa-server"] entry must be present');
+		assert.strictEqual(conn.transport, "http", "qa-server transport is http");
+	});
+
+	await test("all 2 quality-assurance tools declare mcpServer: 'qa-server'", () => {
+		const wrongServer = qaAssuranceManifest.tools.filter((t) => t.mcpServer !== "qa-server");
+		assert.strictEqual(
+			wrongServer.length,
+			0,
+			`Tools without mcpServer='qa-server': ${wrongServer.map((t) => t.name).join(", ")}`,
+		);
+	});
+
+	await test("callQAServerTool rejects with a clear error when server is unreachable", async () => {
+		let threw = false;
+		try {
+			await callQAServerTool("http://localhost:19999", "run_quality_tests", { targets: ["test"] });
+		} catch (err) {
+			threw = true;
+			const msg = err instanceof Error ? err.message : String(err);
+			assert.ok(msg.length > 0, "Error message must be non-empty");
+		}
+		assert.ok(threw, "callQAServerTool must throw when server is unreachable");
+	});
+
+	const live = await qaServerReachable();
+	if (!live) {
+		console.log("\n  ⚠️  [integration] QA server not reachable at localhost:3004 — skipping live MCP call tests.");
+		console.log("     Start qa-server with: PORT=3004 cd servers/qa-server && pnpm start");
+	} else {
+		await test("[integration] callQAServerTool routes run_quality_tests through qa-server MCP", async () => {
+			const result = await callQAServerTool(qaAssuranceConfig.mcpServers["qa-server"].url, "run_quality_tests", {
+				targets: ["test-component"],
+				testSuite: "functional",
+			});
+			assert.ok(result !== undefined, "MCP call must return a value");
+		});
+	}
+
+	console.log(`\nQuality Assurance MCP Client Tests: ${passed} passed, ${failed} failed`);
+
+	if (failed > 0) {
+		process.exit(1);
+	}
+}
+
+await runTests();

--- a/agents/quality-assurance/tsconfig.json
+++ b/agents/quality-assurance/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,28 @@ importers:
         specifier: ^6.0.2
         version: 6.0.3
 
+  agents/quality-assurance:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
+      '@shaleyeah/sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+    devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.11
+        version: 2.4.16
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.9.1
+      tsx:
+        specifier: ^4.21.0
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.3
+
   agents/reporter-agent:
     dependencies:
       '@shaleyeah/sdk':


### PR DESCRIPTION
## Summary

- New `agents/quality-assurance/` package — **Testius Validatus** — Tier 2 agent wrapping `@shaleyeah/server-qa` over MCP HTTP transport
- Follows the exact `agents/geologist/` pattern (`callGeowizTool` → `callQAServerTool`, same manifest/config/runtime/endpoint shape)
- 2 agent tools: `quality-assurance.run_quality_tests` (`standard-analysis`) and `quality-assurance.generate_quality_report` (`deterministic`)
- Default qa-server URL: `http://localhost:3004` (operator-configurable via `AgentRuntimeConfig.mcpServers["qa-server"].url`)

## Test plan

- [x] `tests/mcp-client.test.ts` — 5 tests: `callQAServerTool` export, config wiring (URL + transport), all tools declare `mcpServer: "qa-server"`, error propagation when unreachable
- [x] `tests/agent.test.ts` — 37 tests: manifest validation, progressive discovery, model routing, HITL policy, evals, standalone boot, invalid manifest rejection
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` (Biome) — clean
- [x] Root `CHANGELOG.md` updated under `[Unreleased]`
- [x] Per-package `CHANGELOG.md`, `README.md`, `docs/ARCHITECTURE.md`, `docs/DEPLOYMENT.md` added

🤖 Generated with [Claude Code](https://claude.com/claude-code)