### PR TITLE
feat(title): split title server into 4 domain modules + implement title-analyst agent (#372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **title / title-analyst pair — Steps A + B** (#372) — Full Tier 1 server modularization and Tier 2 agent implementation for oil & gas title analysis.
+  - `servers/title/src/tools/` — 4 focused modules (ownership, lease-analysis, burden-check, chain-of-title) with LLM synthesis + deterministic fallbacks; `tests/tools.test.ts` (22 tests)
+  - `agents/title-analyst/src/agent/` — manifest (4 tools, port 3010), runtime config, `runTitleAnalystTask()` Layer 2 loop, title MCP HTTP client; `tests/mcp-client.test.ts` (13) + `tests/agent.test.ts` (31)
+
 ### Fixed
 
 - **CI: invalid pnpm/action-setup SHA** — replaced non-existent commit hash `fe02b74` with correct v4.1.0 SHA `a7487c7e` in `ci.yml`, `codeql.yml`, and `release.yml`; both "PR checks" and "CodeQL Security Analysis" jobs were failing at "Set up job" before running any code.

--- a/agents/title-analyst/CHANGELOG.md
+++ b/agents/title-analyst/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog — @shaleyeah/title-analyst
+
+## [Unreleased]
+
+### Added
+
+- **Step B: Tier 2 agent implementation** (#372) — Full title-analyst agent replacing the stub:
+  - `src/agent/title-client.ts` — MCP HTTP client with Timeout Boundary, Recovery Guide, and Error Classification Arcade patterns
+  - `src/agent/index.ts` — `titleAnalystManifest` (4 tools), `titleAnalystConfig` (port 3010), `createTitleAnalystRuntime()`, `createTitleAnalystEndpoint()`, `runTitleAnalystTask()` (Layer 2 LLM execution loop)
+  - `tests/mcp-client.test.ts` — 13 tests for Layer 1 client and Layer 2 runTask loop
+  - `tests/agent.test.ts` — 31 contract tests: manifest/config validation, progressive discovery, model routing, HITL, evals, health endpoint, scope enforcement, blocking eval halt, invalid manifest rejection
+
+## [0.1.0] — 2026-06-04
+
+### Added
+
+- Initial package stub created during monorepo conversion (#385)

--- a/agents/title-analyst/package.json
+++ b/agents/title-analyst/package.json
@@ -4,16 +4,22 @@
   "description": "Title Analyst — Tier 2 intelligence layer for title analysis",
   "private": true,
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/agent/index.js",
   "scripts": {
     "build": "tsc",
+    "start": "tsx src/agent/index.ts",
+    "test": "bash ../../scripts/run-tests.sh",
+    "lint": "biome check .",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@shaleyeah/sdk": "workspace:*"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.11",
     "@types/node": "^25.6.0",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.2"
   }
 }

--- a/agents/title-analyst/src/agent/index.ts
+++ b/agents/title-analyst/src/agent/index.ts
@@ -1,0 +1,374 @@
+import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
+import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import { callTitleTool } from "./title-client.js";
+
+export { callTitleTool };
+
+export const titleAnalystManifest: AgentManifest = {
+    id: "title-analyst",
+    role: "title-analyst",
+    version: "0.1.0",
+    description:
+        "Titulus Verificatus — standalone title analyst agent that examines O&G property ownership, lease terms, encumbrances, and chain of title via the title MCP server.",
+    persona: {
+        name: "Titulus Verificatus",
+        role: "Master Title Analyst",
+        expertise: [
+            "Title examination and verification",
+            "Working interest (WI) and net revenue interest (NRI) analysis",
+            "Lease term parsing and expiry risk assessment",
+            "Encumbrance and burden identification (ORRI, production payments, liens)",
+            "Chain of title validation and curative requirements",
+        ],
+    },
+    capabilities: [
+        "ownership-analysis",
+        "lease-analysis",
+        "burden-check",
+        "chain-of-title",
+        "model-routing",
+        "evals",
+    ],
+    tools: [
+        {
+            name: "title-analyst.examine_ownership",
+            description: "Analyze working interest (WI) and net revenue interest (NRI) for an O&G property.",
+            type: "query",
+            capabilities: ["ownership-analysis"],
+            inputSchema: {
+                type: "object",
+                properties: {
+                    propertyDescription: { type: "string", description: "Legal description of the property" },
+                    county: { type: "string" },
+                    state: { type: "string" },
+                    outputPath: { type: "string", description: "Optional path to write JSON output" },
+                },
+                required: ["propertyDescription", "county", "state"],
+            },
+            readOnly: true,
+            destructive: false,
+            requiresHumanApproval: false,
+            requiredScopes: ["read:title"],
+            modelRequirement: "standard-analysis",
+            evalProfile: "title-analyst-ownership",
+            mcpServer: "title",
+        },
+        {
+            name: "title-analyst.analyze_lease",
+            description: "Parse lease terms and assess expiry risk, depth severance, and acreage limitations.",
+            type: "query",
+            capabilities: ["lease-analysis"],
+            inputSchema: {
+                type: "object",
+                properties: {
+                    primaryTerm: { type: "string", description: "Lease primary term, e.g. '3 years' or '36 months'" },
+                    county: { type: "string" },
+                    state: { type: "string" },
+                    examPeriod: { type: "string", default: "20 years" },
+                    outputPath: { type: "string", description: "Optional path to write JSON output" },
+                },
+                required: ["primaryTerm", "county", "state"],
+            },
+            readOnly: true,
+            destructive: false,
+            requiresHumanApproval: false,
+            requiredScopes: ["read:title"],
+            modelRequirement: "standard-analysis",
+            evalProfile: "title-analyst-lease",
+            mcpServer: "title",
+        },
+        {
+            name: "title-analyst.check_burdens",
+            description: "Identify ORRI, production payments, liens, and other encumbrances on an O&G property.",
+            type: "query",
+            capabilities: ["burden-check"],
+            inputSchema: {
+                type: "object",
+                properties: {
+                    propertyDescription: { type: "string", description: "Legal description of the property" },
+                    county: { type: "string" },
+                    state: { type: "string" },
+                    outputPath: { type: "string", description: "Optional path to write JSON output" },
+                },
+                required: ["propertyDescription", "county", "state"],
+            },
+            readOnly: true,
+            destructive: false,
+            requiresHumanApproval: false,
+            requiredScopes: ["read:title"],
+            modelRequirement: "standard-analysis",
+            evalProfile: "title-analyst-burdens",
+            mcpServer: "title",
+        },
+        {
+            name: "title-analyst.trace_chain_of_title",
+            description: "Validate conveyance chain, identify gaps, and list curative requirements.",
+            type: "query",
+            capabilities: ["chain-of-title"],
+            inputSchema: {
+                type: "object",
+                properties: {
+                    propertyDescription: { type: "string", description: "Legal description of the property" },
+                    county: { type: "string" },
+                    state: { type: "string" },
+                    examPeriod: { type: "string", default: "20 years" },
+                    outputPath: { type: "string", description: "Optional path to write JSON output" },
+                },
+                required: ["propertyDescription", "county", "state"],
+            },
+            readOnly: true,
+            destructive: false,
+            requiresHumanApproval: false,
+            requiredScopes: ["read:title"],
+            modelRequirement: "standard-analysis",
+            evalProfile: "title-analyst-chain",
+            mcpServer: "title",
+        },
+    ],
+    requiredScopes: ["read:title"],
+    providerRequirements: [
+        {
+            type: "llm",
+            required: true,
+            description: "Anthropic Claude — standard analysis for title synthesis across ownership, lease, and chain tools.",
+        },
+    ],
+    compatibility: {
+        agentRuntime: "^0.1.0",
+        remoteEndpoint: "^0.1.0",
+        mcp: "2025-03",
+    },
+    health: {
+        readinessChecks: ["manifest", "runtime-config", "tool-handlers", "model-routing"],
+    },
+    memory: {
+        namespace: "title-analyst",
+        reviewRequired: true,
+        sharedMemoryOptIn: false,
+    },
+    evals: {
+        defaultProfile: "title-analyst-default",
+        requiredChecks: ["schema", "redactSecrets"],
+    },
+    autonomy: {
+        defaultLevel: "assistive",
+        allowedLevels: ["assistive", "reviewed"],
+    },
+};
+
+export const titleAnalystConfig: AgentRuntimeConfig = {
+    autonomy: "assistive",
+    modelRouting: {
+        "small-fast":         { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+        "standard-analysis":  { provider: "anthropic", model: "claude-sonnet-4-6" },
+        "deep-reasoning":     { provider: "anthropic", model: "claude-opus-4-8" },
+        "local-private":      { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+        "deterministic":      { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+    },
+    hitl: {
+        approvalMode: "when-sensitive",
+        requireForDestructive: true,
+        requireForMemoryPromotion: true,
+    },
+    evals: {
+        enabled: true,
+        profile: "title-analyst-default",
+        checks: {
+            schema: "blocking",
+            domainCompleteness: "advisory",
+            confidenceMinimum: 0.7,
+            requireSources: false,
+            redactSecrets: "blocking",
+            memoryPromotion: "reviewed-only",
+        },
+    },
+    memory: {
+        enabled: true,
+        namespace: "title-analyst",
+        vectorStore: { enabled: false },
+        retentionDays: 30,
+        promotion: { requireHumanReview: true, allowSharedMemory: false },
+    },
+    mcpServers: {
+        title: {
+            url: process.env.TITLE_MCP_URL ?? "http://localhost:3010",
+            transport: "http",
+            authType: "none",
+        },
+    },
+    dataConnectors: {},
+};
+
+function titleUrl(config: AgentRuntimeConfig): string {
+    return config.mcpServers?.["title"]?.url ?? "http://localhost:3010";
+}
+
+const handlers: Record<string, StandaloneToolHandler> = {
+    "title-analyst.examine_ownership": ({ args, config }) =>
+        callTitleTool(titleUrl(config), "examine_ownership", args as Record<string, unknown>),
+
+    "title-analyst.analyze_lease": ({ args, config }) =>
+        callTitleTool(titleUrl(config), "analyze_lease", args as Record<string, unknown>),
+
+    "title-analyst.check_burdens": ({ args, config }) =>
+        callTitleTool(titleUrl(config), "check_burdens", args as Record<string, unknown>),
+
+    "title-analyst.trace_chain_of_title": ({ args, config }) =>
+        callTitleTool(titleUrl(config), "trace_chain_of_title", args as Record<string, unknown>),
+};
+
+export function createTitleAnalystRuntime(config: AgentRuntimeConfig = titleAnalystConfig): LocalAgentRuntime {
+    return new LocalAgentRuntime({ manifest: titleAnalystManifest, config, handlers });
+}
+
+export function createTitleAnalystEndpoint(config: AgentRuntimeConfig = titleAnalystConfig): LocalAgentEndpoint {
+    return new LocalAgentEndpoint(createTitleAnalystRuntime(config));
+}
+
+/**
+ * Run a multi-step title analysis task driven by the LLM (Layer 2 execution loop).
+ *
+ * All tool calls route through LocalAgentRuntime.execute() — HITL gate, scope
+ * checks, and audit logging fire on every step (Arcade #46: Permission Gate).
+ *
+ * options.runtime            — caller-managed runtime (e.g. in tests)
+ * options.onApprovalRequired — HITL callback; throws if omitted and approval is required
+ *
+ * Deferred (#395): Context Injection — read/write memory namespace around the loop.
+ * Deferred (#396): Async Job — polling for long-running tools.
+ */
+export async function runTitleAnalystTask(
+    goal: string,
+    options: {
+        config?: AgentRuntimeConfig;
+        apiKey?: string;
+        runtime?: LocalAgentRuntime;
+        onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+    } = {},
+): Promise<string> {
+    const config = options.config ?? titleAnalystConfig;
+
+    let runtime = options.runtime;
+    let ownedRuntime = false;
+    if (!runtime) {
+        runtime = createTitleAnalystRuntime(config);
+        await runtime.initialize();
+        ownedRuntime = true;
+    }
+
+    try {
+        return await executeLoop(goal, runtime, options);
+    } finally {
+        if (ownedRuntime) await runtime.shutdown();
+    }
+}
+
+function buildTranscript(history: Array<{ role: "user" | "assistant" | "tool"; content: string }>): string {
+    return history
+        .map((t) => {
+            if (t.role === "user") return `User: ${t.content}`;
+            if (t.role === "assistant") return `Assistant: ${t.content}`;
+            return `Tool result: ${t.content}`;
+        })
+        .join("\n\n");
+}
+
+function parseJson(text: string): { action?: string; tool?: string; args?: Record<string, unknown>; answer?: string } | null {
+    try {
+        const cleaned = text.replace(/^```(?:json)?\s*/m, "").replace(/\s*```\s*$/m, "").trim();
+        return JSON.parse(cleaned);
+    } catch {
+        return null;
+    }
+}
+
+async function executeLoop(
+    goal: string,
+    runtime: LocalAgentRuntime,
+    options: {
+        apiKey?: string;
+        onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+    },
+): Promise<string> {
+    // TODO (#395): Context Injection — read from memory.namespace before building system prompt.
+
+    const toolDefs = titleAnalystManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+
+    const system = `You are ${titleAnalystManifest.persona.name}, ${titleAnalystManifest.persona.role}.
+
+Available tools:
+${toolDefs}
+
+Respond ONLY with valid JSON — no prose, no markdown. Two formats allowed:
+1. Call a tool:  {"action":"tool","tool":"<full tool name>","args":{...}}
+2. Final answer: {"action":"done","answer":"<synthesized answer>"}
+
+Always use the full tool name (e.g. "title-analyst.examine_ownership").
+If you cannot complete the task with the available tools, respond with {"action":"done","answer":"<explanation>"}.`;
+
+    type Turn = { role: "user" | "assistant" | "tool"; content: string };
+    const history: Turn[] = [{ role: "user", content: goal }];
+    const MAX_STEPS = 8;
+
+    for (let step = 0; step < MAX_STEPS; step++) {
+        const response = await callLLM({
+            system,
+            prompt: `${buildTranscript(history)}\n\nAssistant:`,
+            apiKey: options.apiKey,
+        });
+
+        history.push({ role: "assistant", content: response });
+
+        const parsed = parseJson(response);
+        if (!parsed || parsed.action === "done" || !parsed.tool) {
+            return parsed?.answer ?? response;
+        }
+
+        // TODO (#396): Async Job — detect asyncJob tools and poll instead of blocking.
+
+        // Permission Gate: all tool calls go through runtime.execute() — never call
+        // callTitleTool directly from the loop.
+        const execResult = await runtime.execute({
+            toolName: parsed.tool,
+            args: parsed.args ?? {},
+            runId: `task:step:${step}`,
+        });
+
+        if (execResult.status === "completed") {
+            history.push({ role: "tool", content: JSON.stringify(execResult.data) });
+        } else if (execResult.status === "approval_required") {
+            if (!options.onApprovalRequired) {
+                throw new Error(
+                    `Tool ${parsed.tool} requires human approval. ` +
+                        "Provide an onApprovalRequired callback to runTitleAnalystTask, or set autonomy to 'autonomous'.",
+                );
+            }
+            const approval = await options.onApprovalRequired(execResult.challenge);
+            const approved = await runtime.execute({
+                toolName: parsed.tool,
+                args: parsed.args ?? {},
+                approval,
+                runId: `task:step:${step}:approved`,
+            });
+            if (approved.status === "completed") {
+                history.push({ role: "tool", content: JSON.stringify(approved.data) });
+            } else {
+                const err = approved.status === "failed" ? approved.error : "approval re-execution failed";
+                history.push({ role: "tool", content: `Error after approval for ${parsed.tool}: ${err}` });
+            }
+        } else {
+            const hint = execResult.retryable ? " (retryable — server may be temporarily unavailable)" : " (permanent)";
+            history.push({ role: "tool", content: `Error calling ${parsed.tool}: ${execResult.error}${hint}` });
+        }
+    }
+
+    // TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+
+    const finalResponse = await callLLM({
+        system,
+        prompt: `${buildTranscript(history)}\n\nUser: Maximum steps reached. Synthesize findings now.\n\nAssistant:`,
+        apiKey: options.apiKey,
+    });
+
+    return parseJson(finalResponse)?.answer ?? finalResponse;
+}

--- a/agents/title-analyst/src/agent/title-client.ts
+++ b/agents/title-analyst/src/agent/title-client.ts
@@ -1,0 +1,57 @@
+/**
+ * Title MCP client — thin wrapper that connects to the title Tier 1 server over HTTP,
+ * calls a single tool, and closes the connection.
+ * One-shot per call: simpler than managing a persistent connection for a standalone agent
+ * that may not run co-located with the title server at all times.
+ *
+ * Implements Arcade patterns:
+ *   #28 Timeout Boundary — configurable timeoutMs, default 30s
+ *   #39 Recovery Guide   — error messages include tool name and cause
+ *   #40 Error Classification — RetryableToolError vs PermanentToolError
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { PermanentToolError, RetryableToolError } from "@shaleyeah/sdk";
+
+export async function callTitleTool(
+    url: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    options: { timeoutMs?: number } = {},
+): Promise<unknown> {
+    const timeoutMs = options.timeoutMs ?? 30_000;
+
+    const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(
+            () => reject(new RetryableToolError(`Tool call to ${toolName} timed out after ${timeoutMs}ms`)),
+            timeoutMs,
+        ),
+    );
+
+    const callPromise = (async () => {
+        const transport = new StreamableHTTPClientTransport(new URL(url));
+        const client = new Client({ name: "title-analyst", version: "0.1.0" });
+        await client.connect(transport);
+        try {
+            const result = await client.callTool({ name: toolName, arguments: args });
+            return result.content;
+        } finally {
+            await client.close().catch(() => {});
+        }
+    })();
+
+    try {
+        return await Promise.race([callPromise, timeoutPromise]);
+    } catch (err) {
+        if (err instanceof RetryableToolError || err instanceof PermanentToolError) throw err;
+
+        const msg = err instanceof Error ? err.message : String(err);
+
+        if (/ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENETUNREACH|fetch failed/i.test(msg)) {
+            throw new RetryableToolError(`Network error calling ${toolName}: ${msg}`, err instanceof Error ? err : undefined);
+        }
+
+        throw new PermanentToolError(`Tool call to ${toolName} failed: ${msg}`, err instanceof Error ? err : undefined);
+    }
+}

--- a/agents/title-analyst/src/index.ts
+++ b/agents/title-analyst/src/index.ts
@@ -16,5 +16,4 @@
 
 export const AGENT_ID = "title-analyst";
 
-// Uncomment and switch to this export once src/agent/index.ts is implemented:
-// export * from "./agent/index.js";
+export * from "./agent/index.js";

--- a/agents/title-analyst/tests/agent.test.ts
+++ b/agents/title-analyst/tests/agent.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Title Analyst Agent Contract Tests — Issue #372
+ *
+ * Proves the title server tools are accessible through the AgentRuntime contract
+ * and that the title-analyst manifest satisfies all Arcade acceptance criteria.
+ */
+
+import { AgentManifestSchema, AgentRuntimeConfigSchema, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+    createTitleAnalystEndpoint,
+    createTitleAnalystRuntime,
+    titleAnalystConfig,
+    titleAnalystManifest,
+} from "../src/agent/index.js";
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, message: string): void {
+    if (condition) {
+        console.log(`  ✅ ${message}`);
+        passed++;
+    } else {
+        console.error(`  ❌ ${message}`);
+        failed++;
+    }
+}
+
+async function titleServerReachable(): Promise<boolean> {
+    try {
+        const url = titleAnalystConfig.mcpServers?.["title"]?.url ?? "http://localhost:3010";
+        const ctrl = new AbortController();
+        const timer = setTimeout(() => ctrl.abort(), 500);
+        await fetch(url, { method: "HEAD", signal: ctrl.signal });
+        clearTimeout(timer);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+console.log("🧪 Starting Title Analyst Agent Contract Tests (#372)\n");
+
+console.log("📋 Testing manifest and config validation...");
+{
+    const manifest = AgentManifestSchema.safeParse(titleAnalystManifest);
+    assert(manifest.success, "Title analyst manifest validates");
+    if (!manifest.success) console.error("  ", manifest.error.format());
+
+    const config = AgentRuntimeConfigSchema.safeParse(titleAnalystConfig);
+    assert(config.success, "Title analyst runtime config validates");
+
+    assert(titleAnalystManifest.tools.length === 4, "Title analyst exposes 4 title tools");
+    assert(
+        titleAnalystManifest.tools.every((t) => t.name.startsWith("title-analyst.")),
+        "All tools follow title-analyst. naming convention",
+    );
+    assert(
+        titleAnalystManifest.tools.every((t) => !t.modelRequirement.includes("claude")),
+        "Model requirements are capability labels, not provider names",
+    );
+    const allToolScopes = new Set(titleAnalystManifest.tools.flatMap((t) => t.requiredScopes));
+    assert(
+        [...allToolScopes].every((s) => titleAnalystManifest.requiredScopes.includes(s)),
+        "Manifest requiredScopes is a superset of all tool requiredScopes",
+    );
+    const llmReq = titleAnalystManifest.providerRequirements.find((p) => p.type === "llm");
+    assert(llmReq?.required === true, "LLM provider requirement is marked required");
+}
+
+console.log("\n🔎 Testing progressive discovery...");
+{
+    const runtime = createTitleAnalystRuntime();
+    await runtime.initialize();
+
+    const summary = runtime.discover("summary");
+    assert("capabilities" in summary, "Summary discovery returns capabilities");
+    assert(!("tools" in summary), "Summary discovery does not include tool list");
+
+    const tools = runtime.discover("tools");
+    assert(Array.isArray(tools) && tools.length === 4, "Tool discovery returns 4 tools");
+    assert(!("inputSchema" in tools[0]), "Tool list omits input schemas");
+
+    const schema = runtime.discover("schema", "title-analyst.examine_ownership");
+    assert(schema?.inputSchema !== undefined, "Schema discovery returns examine_ownership input schema");
+    assert(
+        (schema?.inputSchema as Record<string, unknown>)?.required !== undefined,
+        "examine_ownership schema declares required fields",
+    );
+
+    const missing = runtime.discover("schema", "title-analyst.nonexistent");
+    assert(missing === null, "Schema discovery returns null for unknown tool");
+
+    await runtime.shutdown();
+}
+
+console.log("\n📡 Testing model capability routing across requirement classes...");
+{
+    const runtime = createTitleAnalystRuntime();
+    await runtime.initialize();
+
+    const modelRequirements = new Set(titleAnalystManifest.tools.map((t) => t.modelRequirement));
+    assert(modelRequirements.has("standard-analysis"), "standard-analysis requirement present in tool suite");
+
+    for (const req of modelRequirements) {
+        const binding = titleAnalystConfig.modelRouting[req];
+        assert(binding !== undefined, `Model route exists for requirement: ${req}`);
+    }
+
+    await runtime.shutdown();
+}
+
+console.log("\n🙋 Testing HITL policy wires through to config...");
+{
+    const live = await titleServerReachable();
+
+    if (live) {
+        const runtime = createTitleAnalystRuntime();
+        await runtime.initialize();
+
+        const result = await runtime.execute({
+            toolName: "title-analyst.examine_ownership",
+            args: { propertyDescription: "Section 12 Block A", county: "Reeves", state: "TX" },
+        });
+        assert(result.status === "completed", "Ownership tool completes without approval challenge");
+
+        await runtime.shutdown();
+    } else {
+        console.log("  ⚠️  [skipped] execute() test requires live title server");
+    }
+
+    // approvalMode: "always" blocks BEFORE calling the handler — no server needed
+    const strictRuntime = createTitleAnalystRuntime({
+        ...titleAnalystConfig,
+        hitl: { ...titleAnalystConfig.hitl, approvalMode: "always" },
+    });
+    await strictRuntime.initialize();
+    const blocked = await strictRuntime.execute({
+        toolName: "title-analyst.examine_ownership",
+        args: { propertyDescription: "Section 12 Block A", county: "Reeves", state: "TX" },
+    });
+    assert(blocked.status === "approval_required", "approvalMode: 'always' blocks all tools");
+    if (blocked.status === "approval_required") {
+        assert(blocked.challenge.type === "human_approval_required", "Challenge is structured");
+        assert(blocked.challenge.agentId === "title-analyst", "Challenge identifies title-analyst agent");
+    }
+
+    await strictRuntime.shutdown();
+}
+
+console.log("\n🧪 Testing evals policy is configured correctly...");
+{
+    const live = await titleServerReachable();
+    if (!live) {
+        console.log("  ⚠️  [skipped] eval test requires live title server");
+    } else {
+        const runtime = createTitleAnalystRuntime();
+        await runtime.initialize();
+
+        const result = await runtime.execute({
+            toolName: "title-analyst.examine_ownership",
+            args: { propertyDescription: "Section 12 Block A", county: "Reeves", state: "TX" },
+        });
+
+        assert(result.status === "completed", "examine_ownership completes for eval test");
+        if (result.status === "completed") {
+            assert(
+                result.evals.some((e) => e.check === "schema"),
+                "Schema eval ran",
+            );
+            assert(
+                result.evals.some((e) => e.check === "redactSecrets"),
+                "Secret-redaction eval ran",
+            );
+            assert(
+                result.evals.every((e) => e.status === "pass"),
+                "All evals pass on clean title output",
+            );
+        }
+
+        await runtime.shutdown();
+    }
+}
+
+console.log("\n🏥 Testing health endpoint and standalone boot...");
+{
+    const endpoint = createTitleAnalystEndpoint();
+    const health = await endpoint.health();
+    assert(health.agentId === "title-analyst", "Health endpoint identifies title-analyst");
+    assert(health.status !== "not_ready", "Title analyst boots without external dependencies");
+
+    const manifest = await endpoint.manifest();
+    assert(manifest.id === "title-analyst", "Endpoint exposes title-analyst manifest");
+    assert(manifest.tools.length === 4, "Endpoint manifest has 4 tools");
+
+    const toolSchema = await endpoint.discoveryToolSchema("title-analyst.analyze_lease");
+    assert(toolSchema !== null, "Endpoint exposes tool schemas by name");
+}
+
+console.log("\n🔒 Testing scope enforcement...");
+{
+    const runtime = createTitleAnalystRuntime();
+    await runtime.initialize();
+
+    const blocked = await runtime.execute({
+        toolName: "title-analyst.examine_ownership",
+        args: { propertyDescription: "Section 12 Block A", county: "Reeves", state: "TX" },
+        grantedScopes: [],
+    });
+    assert(blocked.status === "failed", "Missing scope blocks tool execution");
+    if (blocked.status === "failed") {
+        assert(blocked.error.includes("Missing required scopes"), "Error message names missing scopes");
+    }
+
+    const allowed = await runtime.execute({
+        toolName: "title-analyst.examine_ownership",
+        args: { propertyDescription: "Section 12 Block A", county: "Reeves", state: "TX" },
+        grantedScopes: ["read:title"],
+    });
+    assert(
+        allowed.status !== "failed" || !allowed.error.includes("Missing required scopes"),
+        "Correct scopes are accepted",
+    );
+
+    await runtime.shutdown();
+}
+
+console.log("\n🧱 Testing blocking eval halt...");
+{
+    const undefinedHandler = async () => undefined;
+    const allHandlers = Object.fromEntries(titleAnalystManifest.tools.map((t) => [t.name, undefinedHandler]));
+    const testRuntime = new LocalAgentRuntime({
+        manifest: titleAnalystManifest,
+        config: titleAnalystConfig,
+        handlers: allHandlers,
+    });
+    await testRuntime.initialize();
+    const result = await testRuntime.execute({
+        toolName: "title-analyst.examine_ownership",
+        args: { propertyDescription: "Section 12 Block A", county: "Reeves", state: "TX" },
+    });
+    assert(result.status === "failed", "Blocking eval failure returns status: failed");
+    if (result.status === "failed") {
+        assert(result.error.includes("Blocking eval"), "Error message references blocking eval");
+        assert(result.retryable === false, "Blocking eval failures are not retryable");
+    }
+    await testRuntime.shutdown();
+}
+
+console.log("\n🛑 Testing invalid manifest fails early...");
+{
+    try {
+        new LocalAgentRuntime({
+            manifest: { ...titleAnalystManifest, id: "" } as typeof titleAnalystManifest,
+            config: titleAnalystConfig,
+            handlers: Object.fromEntries(titleAnalystManifest.tools.map((t) => [t.name, async () => ({})])),
+        });
+        assert(false, "Empty manifest id should fail validation");
+    } catch {
+        assert(true, "Invalid manifest id fails at construction");
+    }
+}
+
+console.log("\n══════════════════════════════════════════════");
+console.log(`Title Analyst Agent Contract Tests: ${passed} passed, ${failed} failed`);
+console.log("══════════════════════════════════════════════");
+
+if (failed > 0) {
+    process.exit(1);
+}

--- a/agents/title-analyst/tests/mcp-client.test.ts
+++ b/agents/title-analyst/tests/mcp-client.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Title Analyst MCP Client + runTask Tests — Issue #372
+ *
+ * Layer 1: verifies callTitleTool delegates to the title server over HTTP.
+ * Layer 2: verifies runTitleAnalystTask drives a multi-step LLM loop.
+ *
+ * Run: cd agents/title-analyst && npx tsx tests/mcp-client.test.ts
+ */
+
+import assert from "node:assert";
+import type { HumanApprovalChallenge } from "@shaleyeah/sdk";
+import { PermanentToolError, RetryableToolError } from "@shaleyeah/sdk";
+import { callTitleTool, titleAnalystConfig, titleAnalystManifest, runTitleAnalystTask } from "../src/agent/index.js";
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void | Promise<void>): Promise<void> {
+    return Promise.resolve()
+        .then(fn)
+        .then(() => {
+            console.log(`  ✓ ${name}`);
+            passed++;
+        })
+        .catch((err: unknown) => {
+            console.log(`  ✗ ${name}`);
+            console.log(`    ${err instanceof Error ? err.message : String(err)}`);
+            failed++;
+        });
+}
+
+async function titleServerReachable(): Promise<boolean> {
+    try {
+        const url = titleAnalystConfig.mcpServers?.["title"]?.url ?? "http://localhost:3010";
+        const ctrl = new AbortController();
+        const timer = setTimeout(() => ctrl.abort(), 500);
+        await fetch(url, { method: "HEAD", signal: ctrl.signal });
+        clearTimeout(timer);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function runTests(): Promise<void> {
+    console.log("\n🧪 Title Analyst MCP Client + runTask Tests (#372)\n");
+
+    // ── Layer 1: HTTP client ──────────────────────────────────────────────────
+
+    await test("callTitleTool is exported as a function", () => {
+        assert.strictEqual(typeof callTitleTool, "function", "callTitleTool must be exported");
+    });
+
+    await test('titleAnalystConfig.mcpServers["title"].url is http://localhost:3010', () => {
+        const conn = titleAnalystConfig.mcpServers?.["title"];
+        assert.ok(conn, 'mcpServers["title"] entry must be present');
+        assert.strictEqual(conn.url, "http://localhost:3010", "title URL must be localhost:3010");
+    });
+
+    await test('titleAnalystConfig.mcpServers["title"].transport is http', () => {
+        const conn = titleAnalystConfig.mcpServers?.["title"];
+        assert.ok(conn, 'mcpServers["title"] entry must be present');
+        assert.strictEqual(conn.transport, "http", "title transport must be http");
+    });
+
+    await test("all 4 title-analyst tools declare mcpServer: 'title'", () => {
+        const wrong = titleAnalystManifest.tools.filter((t) => t.mcpServer !== "title");
+        assert.strictEqual(wrong.length, 0, `Tools without mcpServer='title': ${wrong.map((t) => t.name).join(", ")}`);
+    });
+
+    await test("titleAnalystConfig.modelRouting['standard-analysis'] uses a real model ID", () => {
+        const binding = titleAnalystConfig.modelRouting["standard-analysis"];
+        assert.ok(binding, "standard-analysis binding must be present");
+        assert.notStrictEqual(binding?.model, "configured-by-operator", "model must not be a placeholder");
+        assert.strictEqual(binding?.provider, "anthropic", "provider must be anthropic");
+    });
+
+    await test("callTitleTool rejects with a clear error when server is unreachable", async () => {
+        let threw = false;
+        try {
+            await callTitleTool("http://localhost:19998", "examine_ownership", {
+                propertyDescription: "Section 12 Block A",
+                county: "Reeves",
+                state: "TX",
+            });
+        } catch (err) {
+            threw = true;
+            const msg = err instanceof Error ? err.message : String(err);
+            assert.ok(msg.length > 0, "Error message must be non-empty");
+        }
+        assert.ok(threw, "callTitleTool must throw when server is unreachable");
+    });
+
+    // ── Layer 2: runTask execution loop ───────────────────────────────────────
+
+    await test("runTitleAnalystTask is exported as a function", () => {
+        assert.strictEqual(typeof runTitleAnalystTask, "function", "runTitleAnalystTask must be exported");
+    });
+
+    await test("runTitleAnalystTask throws when no ANTHROPIC_API_KEY is set", async () => {
+        const saved = process.env.ANTHROPIC_API_KEY;
+        process.env.ANTHROPIC_API_KEY = "";
+        let threw = false;
+        try {
+            await runTitleAnalystTask("examine title for Section 12 Reeves County TX");
+        } catch (err) {
+            threw = true;
+            const msg = err instanceof Error ? err.message : String(err);
+            assert.ok(msg.includes("ANTHROPIC_API_KEY"), `Error must mention ANTHROPIC_API_KEY, got: ${msg}`);
+        } finally {
+            if (saved !== undefined) process.env.ANTHROPIC_API_KEY = saved;
+            else delete process.env.ANTHROPIC_API_KEY;
+        }
+        assert.ok(threw, "runTitleAnalystTask must throw when no API key is set");
+    });
+
+    await test("runTitleAnalystTask hits callLLM when API key is present (auth error confirms path)", async () => {
+        let threw = false;
+        try {
+            await runTitleAnalystTask("examine title for Section 12 Reeves County TX", {
+                apiKey: "sk-ant-invalid-key-for-test",
+            });
+        } catch (err) {
+            threw = true;
+            const msg = err instanceof Error ? err.message : String(err);
+            assert.ok(msg.length > 0, "Error from invalid key must have a message");
+        }
+        assert.ok(threw, "runTitleAnalystTask with invalid key must throw (proves callLLM was hit)");
+    });
+
+    // ── SDK error exports ─────────────────────────────────────────────────────
+
+    await test("RetryableToolError is exported from @shaleyeah/sdk", () => {
+        assert.strictEqual(typeof RetryableToolError, "function");
+        const err = new RetryableToolError("test");
+        assert.strictEqual(err.retryable, true);
+    });
+
+    await test("PermanentToolError is exported from @shaleyeah/sdk", () => {
+        assert.strictEqual(typeof PermanentToolError, "function");
+        const err = new PermanentToolError("test");
+        assert.strictEqual(err.retryable, false);
+    });
+
+    // ── runTitleAnalystTask runtime option ────────────────────────────────────
+
+    await test("runTitleAnalystTask accepts runtime option (signature check)", () => {
+        const params = runTitleAnalystTask.length;
+        assert.ok(params >= 1, "runTitleAnalystTask must accept at least a goal argument");
+    });
+
+    await test("runTitleAnalystTask throws when approval_required and no onApprovalRequired callback", async () => {
+        const { createTitleAnalystRuntime } = await import("../src/agent/index.js");
+        const runtime = createTitleAnalystRuntime({
+            ...titleAnalystConfig,
+            hitl: { ...titleAnalystConfig.hitl, approvalMode: "always" },
+        });
+        await runtime.initialize();
+        const result = await runtime.execute({
+            toolName: "title-analyst.examine_ownership",
+            args: { propertyDescription: "Section 12 Block A", county: "Reeves", state: "TX" },
+        });
+        await runtime.shutdown();
+        assert.strictEqual(result.status, "approval_required", "HITL gate must block with approvalMode='always'");
+        assert.ok("challenge" in result, "approval_required result must have a challenge");
+        const challenge = (result as { status: "approval_required"; challenge: HumanApprovalChallenge }).challenge;
+        assert.strictEqual(challenge.toolName, "title-analyst.examine_ownership");
+    });
+
+    // ── Integration tests (require live title server + real API key) ──────────
+
+    const live = await titleServerReachable();
+    const HAS_API_KEY = !!process.env.ANTHROPIC_API_KEY;
+
+    if (!live) {
+        console.log("\n  ⚠️  [integration] title server not reachable at localhost:3010 — skipping live MCP tests.");
+        console.log("     Start with: cd servers/title && PORT=3010 pnpm start");
+    }
+    if (!HAS_API_KEY) {
+        console.log("  ⚠️  [integration] ANTHROPIC_API_KEY not set — skipping runTask live test.");
+    }
+
+    if (live) {
+        await test("[integration] callTitleTool routes examine_ownership through title MCP", async () => {
+            const result = await callTitleTool(titleAnalystConfig.mcpServers!["title"].url, "examine_ownership", {
+                propertyDescription: "Section 12 Block A",
+                county: "Reeves",
+                state: "TX",
+            });
+            assert.ok(result !== undefined, "MCP tool call must return a value");
+        });
+    }
+
+    if (live && HAS_API_KEY) {
+        await test("[integration] runTitleAnalystTask completes a multi-step title task", async () => {
+            const answer = await runTitleAnalystTask(
+                "Examine the ownership and chain of title for Section 12 Block A in Reeves County, TX and summarize your findings.",
+            );
+            assert.strictEqual(typeof answer, "string", "runTitleAnalystTask must return a string");
+            assert.ok(answer.length > 0, "Answer must be non-empty");
+        });
+    }
+
+    console.log(`\nTitle Analyst MCP Client + runTask Tests: ${passed} passed, ${failed} failed`);
+    if (failed > 0) process.exit(1);
+}
+
+await runTests();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,13 +235,22 @@ importers:
 
   agents/title-analyst:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@shaleyeah/sdk':
         specifier: workspace:*
         version: link:../../sdk
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.11
+        version: 2.4.16
       '@types/node':
         specifier: ^25.6.0
         version: 25.9.1
+      tsx:
+        specifier: ^4.21.0
+        version: 4.22.4
       typescript:
         specifier: ^6.0.2
         version: 6.0.3

--- a/servers/title/CHANGELOG.md
+++ b/servers/title/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Step A: Tier 1 server modularization** (#372) — Split monolithic `src/index.ts` (single `examine_title` tool) into four focused domain modules under `src/tools/`:
+  - `ownership.ts` — WI/NRI calculations, `calculateNRI()`, `deriveOwnershipBreakdown()`, `synthesizeOwnershipWithLLM()`
+  - `lease-analysis.ts` — lease term parsing, `parseLeaseTermMonths()`, `deriveLeaseAnalysis()`, `synthesizeLeaseAnalysisWithLLM()`
+  - `burden-check.ts` — ORRI/encumbrance identification, `calculateTotalBurden()`, `deriveBurdenAssessment()`, `synthesizeBurdenCheckWithLLM()`
+  - `chain-of-title.ts` — conveyance chain validation, `assessChainRisk()`, `deriveChainOfTitle()`, `synthesizeChainOfTitleWithLLM()`
+- **Four MCP tools** replace the single `examine_title`: `examine_ownership`, `analyze_lease`, `check_burdens`, `trace_chain_of_title`
+- `tests/tools.test.ts` — 22 tests covering domain math and parsing (NRI formula, lease term parsing, burden totals, chain risk scoring)
+
 ## [0.1.0] — 2026-06-04
 
 ### Added

--- a/servers/title/src/index.ts
+++ b/servers/title/src/index.ts
@@ -1,168 +1,180 @@
 #!/usr/bin/env node
 
 /**
- * Title MCP Server - DRY Refactored Version
+ * Title MCP Server — Titulus Verificatus, Master Title Analyst
  *
- * Demonstrates DRY principles using ServerFactory
- * Reduces boilerplate from ~95 lines to ~35 lines
+ * Four focused tools covering the core title workflow:
+ *   examine_ownership    → WI/NRI split, royalty, ORRI
+ *   analyze_lease        → primary term, expiry risk, depth/acreage limits
+ *   check_burdens        → encumbrances, production payments, ORRI verification
+ *   trace_chain_of_title → conveyance chain gaps, curative requirements
+ *
+ * Business logic lives in src/tools/. This file is a thin facade that wires
+ * each tool to its domain module and registers them on the MCP server.
  */
 
-import { callLLM, type MCPServer, runMCPServer, ServerFactory, type ServerTemplate, ServerUtils } from "@shaleyeah/sdk";
+import type { MCPServer } from "@shaleyeah/sdk";
+import { runMCPServer, ServerFactory, type ServerTemplate, ServerUtils } from "@shaleyeah/sdk";
 import { z } from "zod";
+import { synthesizeBurdenCheckWithLLM } from "./tools/burden-check.js";
+import { synthesizeChainOfTitleWithLLM } from "./tools/chain-of-title.js";
+import { synthesizeLeaseAnalysisWithLLM } from "./tools/lease-analysis.js";
+import { synthesizeOwnershipWithLLM } from "./tools/ownership.js";
 
 // ---------------------------------------------------------------------------
-// Exported helpers (used by tests)
+// Re-export types and domain functions for tests and downstream consumers
+// ---------------------------------------------------------------------------
+
+export type { OwnershipBreakdown } from "./tools/ownership.js";
+export type { LeaseAnalysis } from "./tools/lease-analysis.js";
+export type { BurdenAssessment } from "./tools/burden-check.js";
+export type { ChainOfTitleResult } from "./tools/chain-of-title.js";
+export { deriveOwnershipBreakdown, synthesizeOwnershipWithLLM } from "./tools/ownership.js";
+export { deriveLeaseAnalysis, synthesizeLeaseAnalysisWithLLM } from "./tools/lease-analysis.js";
+export { deriveBurdenAssessment, synthesizeBurdenCheckWithLLM } from "./tools/burden-check.js";
+export { deriveChainOfTitle, synthesizeChainOfTitleWithLLM } from "./tools/chain-of-title.js";
+
+// ---------------------------------------------------------------------------
+// Legacy interface — kept so existing server.test.ts imports don't break
 // ---------------------------------------------------------------------------
 
 export interface TitleFindings {
-	clearTitle: boolean;
-	ownershipPercentage: number;
-	riskLevel: "low" | "medium" | "high";
-	encumbrances: number;
-	notes: string;
+    clearTitle: boolean;
+    ownershipPercentage: number;
+    riskLevel: "low" | "medium" | "high";
+    encumbrances: number;
+    notes: string;
 }
 
 /**
- * Rule-based title findings — fallback when the API is unavailable.
- * Varies by exam period and county so different inputs give different outputs.
+ * Rule-based title findings — backward-compat shim used by server.test.ts.
+ * New code should call the focused domain functions exported above.
  */
 export function deriveDefaultTitleFindings(
-	propertyDescription: string,
-	county: string,
-	examPeriod: string,
+    propertyDescription: string,
+    county: string,
+    examPeriod: string,
 ): TitleFindings {
-	// Longer exam periods and multi-parcel descriptions suggest more complexity
-	const isComplex = propertyDescription.includes(",") || examPeriod.includes("40") || examPeriod.includes("50");
-	const isKnownActiveCounty = ["reeves", "midland", "lea", "weld"].some((c) => county.toLowerCase().includes(c));
+    const isComplex = propertyDescription.includes(",") || examPeriod.includes("40") || examPeriod.includes("50");
+    const isKnownActiveCounty = ["reeves", "midland", "lea", "weld"].some((c) => county.toLowerCase().includes(c));
 
-	return {
-		clearTitle: !isComplex,
-		ownershipPercentage: isComplex ? 75.0 : 87.5,
-		riskLevel: isComplex ? "medium" : isKnownActiveCounty ? "low" : "low",
-		encumbrances: isComplex ? 2 : 1,
-		notes: isComplex
-			? `Complex title chain in ${county} — recommend thorough examination over ${examPeriod}`
-			: `Standard title in ${county} — ${examPeriod} examination period`,
-	};
+    return {
+        clearTitle: !isComplex,
+        ownershipPercentage: isComplex ? 75.0 : 87.5,
+        riskLevel: isComplex ? "medium" : isKnownActiveCounty ? "low" : "low",
+        encumbrances: isComplex ? 2 : 1,
+        notes: isComplex
+            ? `Complex title chain in ${county} — recommend thorough examination over ${examPeriod}`
+            : `Standard title in ${county} — ${examPeriod} examination period`,
+    };
 }
 
-/**
- * Ask Claude (Titulus Verificatus) to assess title risk for the property.
- * Falls back to deriveDefaultTitleFindings() if the API is unavailable.
- */
-export async function synthesizeTitleAnalysisWithLLM(params: {
-	propertyDescription: string;
-	county: string;
-	state: string;
-	examPeriod: string;
-}): Promise<TitleFindings> {
-	const { propertyDescription, county, state, examPeriod } = params;
+// ---------------------------------------------------------------------------
+// Server template — thin wiring, no business logic here
+// ---------------------------------------------------------------------------
 
-	const prompt = `You are Titulus Verificatus, a master oil & gas title analyst.
-
-Assess the title risk for this property and return a JSON object.
-
-PROPERTY:
-Description: ${propertyDescription}
-County: ${county}, ${state}
-Exam period: ${examPeriod}
-
-Return ONLY valid JSON in this exact shape:
-{
-  "clearTitle": true | false,
-  "ownershipPercentage": <number between 50 and 100>,
-  "riskLevel": "low" | "medium" | "high",
-  "encumbrances": <integer number of encumbrances expected>,
-  "notes": "<one sentence describing the key title consideration for this property>"
-}
-
-Base your assessment on realistic title conditions for ${county} County, ${state}.`;
-
-	try {
-		const raw = await callLLM({ prompt, maxTokens: 300 });
-		const match = raw.match(/\{[\s\S]*\}/);
-		if (!match) throw new Error("No JSON in response");
-		const parsed = JSON.parse(match[0]) as Partial<TitleFindings>;
-		const validRisks = ["low", "medium", "high"];
-		if (!validRisks.includes(parsed.riskLevel ?? "")) throw new Error("Invalid riskLevel");
-		return {
-			clearTitle: parsed.clearTitle ?? true,
-			ownershipPercentage: typeof parsed.ownershipPercentage === "number" ? parsed.ownershipPercentage : 87.5,
-			riskLevel: parsed.riskLevel as "low" | "medium" | "high",
-			encumbrances: typeof parsed.encumbrances === "number" ? parsed.encumbrances : 1,
-			notes: parsed.notes ?? "",
-		};
-	} catch (_err) {
-		return deriveDefaultTitleFindings(propertyDescription, county, examPeriod);
-	}
-}
-
-// Define server template with no duplication
 const titleServerTemplate: ServerTemplate = {
-	name: "title",
-	description: "Title & Ownership Analysis MCP Server",
-	persona: {
-		name: "Titulus Verificatus",
-		role: "Master Title Analyst",
-		expertise: [
-			"Title examination and verification",
-			"Ownership structure analysis",
-			"Due diligence investigations",
-			"Lease status verification",
-			"Encumbrance identification",
-		],
-	},
-	directories: ["examinations", "ownership", "reports", "documents"],
-	tools: [
-		ServerFactory.createAnalysisTool(
-			"examine_title",
-			"Conduct comprehensive title examination",
-			z.object({
-				propertyDescription: z.string(),
-				county: z.string(),
-				state: z.string(),
-				examPeriod: z.string().default("20 years"),
-				outputPath: z.string().optional(),
-			}),
-			async (args) => {
-				// Ask Claude to assess realistic title risk for this county and property.
-				// Falls back to rule-based findings if the API is unavailable.
-				const findings = await synthesizeTitleAnalysisWithLLM({
-					propertyDescription: args.propertyDescription,
-					county: args.county,
-					state: args.state,
-					examPeriod: args.examPeriod,
-				});
+    name: "title",
+    description: "Title & Ownership Analysis MCP Server",
+    persona: {
+        name: "Titulus Verificatus",
+        role: "Master Title Analyst",
+        expertise: [
+            "Title examination and verification",
+            "Ownership structure analysis (WI, NRI, ORRI)",
+            "Lease term analysis and expiry risk",
+            "Encumbrance and burden identification",
+            "Chain of title and curative requirements",
+        ],
+    },
+    directories: ["examinations", "ownership", "reports", "documents"],
+    tools: [
+        ServerFactory.createAnalysisTool(
+            "examine_ownership",
+            "Analyze working interest (WI) and net revenue interest (NRI) for an O&G property",
+            z.object({
+                propertyDescription: z.string().describe("Legal description of the property"),
+                county: z.string(),
+                state: z.string(),
+                outputPath: z.string().optional(),
+            }),
+            async (args) => {
+                const result = await synthesizeOwnershipWithLLM({
+                    propertyDescription: args.propertyDescription,
+                    county: args.county,
+                    state: args.state,
+                });
+                return { ...result, confidence: ServerUtils.calculateConfidence(0.9, 0.8) };
+            },
+        ),
 
-				const examination = {
-					property: args.propertyDescription,
-					jurisdiction: `${args.county}, ${args.state}`,
-					examPeriod: args.examPeriod,
-					findings: {
-						clearTitle: findings.clearTitle,
-						encumbrances: findings.encumbrances,
-						ownershipPercentage: findings.ownershipPercentage,
-						legalDescription: "Legal description based on examination",
-						riskLevel: findings.riskLevel,
-						notes: findings.notes,
-					},
-					confidence: ServerUtils.calculateConfidence(0.9, 0.8),
-				};
+        ServerFactory.createAnalysisTool(
+            "analyze_lease",
+            "Parse lease terms and assess expiry risk, depth severance, and acreage limitations",
+            z.object({
+                primaryTerm: z.string().describe("Lease primary term, e.g. '3 years' or '36 months'"),
+                county: z.string(),
+                state: z.string(),
+                examPeriod: z.string().default("20 years"),
+                outputPath: z.string().optional(),
+            }),
+            async (args) => {
+                const result = await synthesizeLeaseAnalysisWithLLM({
+                    primaryTerm: args.primaryTerm,
+                    county: args.county,
+                    state: args.state,
+                    examPeriod: args.examPeriod,
+                });
+                return { ...result, confidence: ServerUtils.calculateConfidence(0.9, 0.8) };
+            },
+        ),
 
-				return examination;
-			},
-		),
-	],
+        ServerFactory.createAnalysisTool(
+            "check_burdens",
+            "Identify ORRI, production payments, liens, and other encumbrances on an O&G property",
+            z.object({
+                propertyDescription: z.string().describe("Legal description of the property"),
+                county: z.string(),
+                state: z.string(),
+                outputPath: z.string().optional(),
+            }),
+            async (args) => {
+                const result = await synthesizeBurdenCheckWithLLM({
+                    propertyDescription: args.propertyDescription,
+                    county: args.county,
+                    state: args.state,
+                });
+                return { ...result, confidence: ServerUtils.calculateConfidence(0.9, 0.8) };
+            },
+        ),
+
+        ServerFactory.createAnalysisTool(
+            "trace_chain_of_title",
+            "Validate conveyance chain, identify gaps, and list curative requirements",
+            z.object({
+                propertyDescription: z.string().describe("Legal description of the property"),
+                county: z.string(),
+                state: z.string(),
+                examPeriod: z.string().default("20 years"),
+                outputPath: z.string().optional(),
+            }),
+            async (args) => {
+                const result = await synthesizeChainOfTitleWithLLM({
+                    propertyDescription: args.propertyDescription,
+                    county: args.county,
+                    state: args.state,
+                    examPeriod: args.examPeriod,
+                });
+                return { ...result, confidence: ServerUtils.calculateConfidence(0.9, 0.8) };
+            },
+        ),
+    ],
 };
 
-// Create the server class using factory (eliminates all boilerplate)
 export const TitleServer = ServerFactory.createServer(titleServerTemplate);
-
-// Export server class
 export default TitleServer;
 
-// Run server if called directly
 if (import.meta.url === `file://${process.argv[1]}`) {
-	const server = new (TitleServer as unknown as new () => MCPServer)();
-	runMCPServer(server);
+    const server = new (TitleServer as unknown as new () => MCPServer)();
+    runMCPServer(server);
 }

--- a/servers/title/src/tools/burden-check.ts
+++ b/servers/title/src/tools/burden-check.ts
@@ -1,0 +1,108 @@
+/**
+ * Burden check — ORRI, production payments, and encumbrance identification.
+ *
+ * Burdens are interests carved out of the lessee's share that reduce net revenue.
+ * Common burdens include:
+ *   - ORRI (Overriding Royalty Interest): a royalty interest out of the lessee's WI
+ *   - Production payments: a right to a share of production for a fixed period/volume
+ *   - Liens and mortgages: security interests against the property
+ *
+ * Total burden = royaltyRate + ORRI + any other production payments.
+ * A net revenue interest (NRI) below 70% of working interest warrants scrutiny.
+ */
+
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface BurdenAssessment {
+    totalBurdenFraction: number; // royalty + ORRI + other, as fraction of WI
+    orriRate: number; // overriding royalty interest fraction
+    productionPaymentDollars: number; // fixed-amount production payment obligations
+    encumbranceCount: number; // total number of encumbrances found
+    liens: string[]; // descriptions of any liens or mortgages
+    riskLevel: "low" | "medium" | "high";
+    notes: string;
+}
+
+/** Aggregate burden fraction = royalty + ORRI. All inputs are fractions (0–1). */
+export function calculateTotalBurden(royaltyRate: number, orriRate: number): number {
+    return royaltyRate + orriRate;
+}
+
+/**
+ * Rule-based burden estimate — deterministic fallback when the API is unavailable.
+ * ORRI is assumed 2% when the property description mentions "override" or "ORRI".
+ */
+export function deriveBurdenAssessment(propertyDescription: string, county: string): BurdenAssessment {
+    const lc = county.toLowerCase();
+    const descLc = propertyDescription.toLowerCase();
+
+    const isPermian = ["reeves", "midland", "ector", "lea", "eddy"].some((c) => lc.includes(c));
+    const royaltyRate = isPermian ? 0.25 : 0.1875;
+
+    const hasOrri = descLc.includes("override") || descLc.includes("orri");
+    const orriRate = hasOrri ? 0.02 : 0;
+
+    const isComplex = propertyDescription.includes(",") || hasOrri;
+    const encumbranceCount = isComplex ? 2 : 1;
+
+    return {
+        totalBurdenFraction: calculateTotalBurden(royaltyRate, orriRate),
+        orriRate,
+        productionPaymentDollars: 0,
+        encumbranceCount,
+        liens: [],
+        riskLevel: isComplex ? "medium" : "low",
+        notes: hasOrri
+            ? `ORRI of ${(orriRate * 100).toFixed(1)}% detected — verify instrument in county records`
+            : `Standard ${isPermian ? "Permian" : "regional"} burden; ${encumbranceCount} encumbrance(s) expected`,
+    };
+}
+
+export async function synthesizeBurdenCheckWithLLM(params: {
+    propertyDescription: string;
+    county: string;
+    state: string;
+}): Promise<BurdenAssessment> {
+    const { propertyDescription, county, state } = params;
+
+    const prompt = `You are Titulus Verificatus, a master oil & gas title analyst.
+
+Assess the burden structure for this property and return valid JSON only.
+
+PROPERTY:
+Description: ${propertyDescription}
+County: ${county}, ${state}
+
+Return ONLY valid JSON in this exact shape:
+{
+  "totalBurdenFraction": <fraction 0–1>,
+  "orriRate": <fraction 0–1>,
+  "productionPaymentDollars": <number>,
+  "encumbranceCount": <integer>,
+  "liens": [<string>, ...],
+  "riskLevel": "low" | "medium" | "high",
+  "notes": "<one sentence on key burden consideration>"
+}
+
+Use realistic burden levels for ${county} County, ${state}. ORRI should only appear when explicitly relevant to the property.`;
+
+    try {
+        const raw = await callLLM({ prompt, maxTokens: 300 });
+        const match = raw.match(/\{[\s\S]*\}/);
+        if (!match) throw new Error("No JSON in response");
+        const parsed = JSON.parse(match[0]) as Partial<BurdenAssessment>;
+        const validRisks = ["low", "medium", "high"];
+        if (!validRisks.includes(parsed.riskLevel ?? "")) throw new Error("Invalid riskLevel");
+        return {
+            totalBurdenFraction: typeof parsed.totalBurdenFraction === "number" ? parsed.totalBurdenFraction : 0.25,
+            orriRate: typeof parsed.orriRate === "number" ? parsed.orriRate : 0,
+            productionPaymentDollars: typeof parsed.productionPaymentDollars === "number" ? parsed.productionPaymentDollars : 0,
+            encumbranceCount: typeof parsed.encumbranceCount === "number" ? parsed.encumbranceCount : 1,
+            liens: Array.isArray(parsed.liens) ? (parsed.liens as string[]) : [],
+            riskLevel: parsed.riskLevel as BurdenAssessment["riskLevel"],
+            notes: parsed.notes ?? "",
+        };
+    } catch {
+        return deriveBurdenAssessment(propertyDescription, county);
+    }
+}

--- a/servers/title/src/tools/chain-of-title.ts
+++ b/servers/title/src/tools/chain-of-title.ts
@@ -1,0 +1,109 @@
+/**
+ * Chain of title — conveyance chain validation and gap identification.
+ *
+ * A clean chain of title requires an unbroken sequence of deeds, assignments, and
+ * conveyances from the original patent or grant to the current owner. Gaps (missing
+ * links) create marketability risk and may require curative instruments (affidavits,
+ * quitclaim deeds, adverse possession proceedings).
+ *
+ * Examination period: most title opinions examine 20–40 years back; complex properties
+ * or those near a patent may require 50+ year chains.
+ */
+
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface ChainOfTitleResult {
+    conveyanceCount: number; // total instruments reviewed in the chain
+    gapsFound: number; // number of missing links requiring curative
+    curative: string[]; // list of curative actions needed
+    oldestRecordYear: number; // earliest year examined
+    continuousChain: boolean; // true when gapsFound === 0
+    riskLevel: "low" | "medium" | "high";
+    notes: string;
+}
+
+/** Map gap count and exam period to risk level. */
+export function assessChainRisk(examPeriodYears: number, gapsFound: number): ChainOfTitleResult["riskLevel"] {
+    if (gapsFound > 2) return "high";
+    if (gapsFound > 0) return "medium";
+    // A very long exam period with no gaps is low risk even for complex properties
+    return "low";
+}
+
+/**
+ * Rule-based chain of title estimate — deterministic fallback when the API is unavailable.
+ * Complex multi-parcel descriptions and long exam periods statistically yield more gaps.
+ */
+export function deriveChainOfTitle(examPeriod: string, county: string, propertyDescription: string): ChainOfTitleResult {
+    const yearMatch = examPeriod.match(/(\d+)/);
+    const examYears = yearMatch ? parseInt(yearMatch[1], 10) : 20;
+
+    const isComplex = propertyDescription.includes(",") || examYears >= 40;
+    const gapsFound = isComplex ? 1 : 0;
+    const curative = gapsFound > 0 ? [`Obtain missing conveyance instrument from ${county} County records`] : [];
+    const oldestRecordYear = new Date().getFullYear() - examYears;
+
+    return {
+        conveyanceCount: isComplex ? 8 : 4,
+        gapsFound,
+        curative,
+        oldestRecordYear,
+        continuousChain: gapsFound === 0,
+        riskLevel: assessChainRisk(examYears, gapsFound),
+        notes: gapsFound > 0
+            ? `${gapsFound} gap(s) found in ${examYears}-year chain — curative instruments required before closing`
+            : `Continuous chain confirmed over ${examYears}-year examination period for ${county}`,
+    };
+}
+
+export async function synthesizeChainOfTitleWithLLM(params: {
+    propertyDescription: string;
+    county: string;
+    state: string;
+    examPeriod: string;
+}): Promise<ChainOfTitleResult> {
+    const { propertyDescription, county, state, examPeriod } = params;
+
+    const prompt = `You are Titulus Verificatus, a master oil & gas title analyst.
+
+Assess the chain of title for this property and return valid JSON only.
+
+PROPERTY:
+Description: ${propertyDescription}
+County: ${county}, ${state}
+Examination period: ${examPeriod}
+
+Return ONLY valid JSON in this exact shape:
+{
+  "conveyanceCount": <integer>,
+  "gapsFound": <integer 0 or more>,
+  "curative": [<string>, ...],
+  "oldestRecordYear": <4-digit year integer>,
+  "continuousChain": true | false,
+  "riskLevel": "low" | "medium" | "high",
+  "notes": "<one sentence on key chain of title consideration>"
+}
+
+Use realistic title chain conditions for ${county} County, ${state}. continuousChain must be true when gapsFound is 0.`;
+
+    try {
+        const raw = await callLLM({ prompt, maxTokens: 300 });
+        const match = raw.match(/\{[\s\S]*\}/);
+        if (!match) throw new Error("No JSON in response");
+        const parsed = JSON.parse(match[0]) as Partial<ChainOfTitleResult>;
+        const validRisks = ["low", "medium", "high"];
+        if (!validRisks.includes(parsed.riskLevel ?? "")) throw new Error("Invalid riskLevel");
+        const gapsFound = typeof parsed.gapsFound === "number" ? parsed.gapsFound : 0;
+        return {
+            conveyanceCount: typeof parsed.conveyanceCount === "number" ? parsed.conveyanceCount : 4,
+            gapsFound,
+            curative: Array.isArray(parsed.curative) ? (parsed.curative as string[]) : [],
+            oldestRecordYear: typeof parsed.oldestRecordYear === "number" ? parsed.oldestRecordYear : new Date().getFullYear() - 20,
+            continuousChain: gapsFound === 0,
+            riskLevel: parsed.riskLevel as ChainOfTitleResult["riskLevel"],
+            notes: parsed.notes ?? "",
+        };
+    } catch {
+        return deriveChainOfTitle(examPeriod, county, propertyDescription);
+    }
+}

--- a/servers/title/src/tools/lease-analysis.ts
+++ b/servers/title/src/tools/lease-analysis.ts
@@ -1,0 +1,108 @@
+/**
+ * Lease term analysis — primary term parsing, expiry risk, and depth/acreage limitations.
+ *
+ * An oil and gas lease has a primary term (fixed years) and a secondary term that
+ * continues as long as production is maintained. Expiry risk rises when the primary
+ * term is short, the lease has been held without production, or a shut-in royalty
+ * clause is absent. Depth severance and acreage limitation clauses constrain what
+ * the lessee can actually develop.
+ */
+
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface LeaseAnalysis {
+    primaryTermMonths: number;
+    royaltyRate: number; // lessor royalty fraction
+    expiryRisk: "low" | "medium" | "high";
+    hasDepthSeverance: boolean; // lease restricted to specific formations
+    hasAcreageLimitation: boolean; // non-participating zone or Pugh clause
+    hasShutInProvisions: boolean; // shut-in royalty preserves lease without production
+    notes: string;
+}
+
+/** Parse common lease term strings to months. Defaults to 36 months if unparseable. */
+export function parseLeaseTermMonths(primaryTerm: string): number {
+    const yearMatch = primaryTerm.match(/(\d+)\s*year/i);
+    if (yearMatch) return parseInt(yearMatch[1], 10) * 12;
+    const monthMatch = primaryTerm.match(/(\d+)\s*month/i);
+    if (monthMatch) return parseInt(monthMatch[1], 10);
+    return 36; // industry default primary term
+}
+
+/**
+ * Rule-based lease analysis — deterministic fallback when the API is unavailable.
+ * Expiry thresholds: >36 months = low risk, 24–36 = medium, <24 = high.
+ */
+export function deriveLeaseAnalysis(primaryTerm: string, county: string, examPeriod: string): LeaseAnalysis {
+    const lc = county.toLowerCase();
+    const termMonths = parseLeaseTermMonths(primaryTerm);
+
+    const isActive = ["reeves", "midland", "lea", "weld", "ector"].some((c) => lc.includes(c));
+    const royaltyRate = isActive ? 0.25 : 0.1875;
+
+    const expiryRisk: LeaseAnalysis["expiryRisk"] = termMonths < 24 ? "high" : termMonths <= 36 ? "medium" : "low";
+
+    // Depth severance typically noted in formation-specific leases or long exam periods
+    const hasDepthSeverance = examPeriod.toLowerCase().includes("formation") || examPeriod.includes("50");
+
+    return {
+        primaryTermMonths: termMonths,
+        royaltyRate,
+        expiryRisk,
+        hasDepthSeverance,
+        hasAcreageLimitation: false,
+        hasShutInProvisions: true, // shut-in clauses are standard in most basins
+        notes: `${termMonths}-month primary term in ${county} — ${expiryRisk} expiry risk; royalty ${(royaltyRate * 100).toFixed(2)}%`,
+    };
+}
+
+export async function synthesizeLeaseAnalysisWithLLM(params: {
+    primaryTerm: string;
+    county: string;
+    state: string;
+    examPeriod: string;
+}): Promise<LeaseAnalysis> {
+    const { primaryTerm, county, state, examPeriod } = params;
+
+    const prompt = `You are Titulus Verificatus, a master oil & gas title analyst.
+
+Analyze the lease terms for this property and return valid JSON only.
+
+PROPERTY:
+Primary term: ${primaryTerm}
+County: ${county}, ${state}
+Examination period: ${examPeriod}
+
+Return ONLY valid JSON in this exact shape:
+{
+  "primaryTermMonths": <integer>,
+  "royaltyRate": <fraction 0–1>,
+  "expiryRisk": "low" | "medium" | "high",
+  "hasDepthSeverance": true | false,
+  "hasAcreageLimitation": true | false,
+  "hasShutInProvisions": true | false,
+  "notes": "<one sentence on key lease consideration>"
+}
+
+Use realistic lease terms for ${county} County, ${state}.`;
+
+    try {
+        const raw = await callLLM({ prompt, maxTokens: 300 });
+        const match = raw.match(/\{[\s\S]*\}/);
+        if (!match) throw new Error("No JSON in response");
+        const parsed = JSON.parse(match[0]) as Partial<LeaseAnalysis>;
+        const validRisks = ["low", "medium", "high"];
+        if (!validRisks.includes(parsed.expiryRisk ?? "")) throw new Error("Invalid expiryRisk");
+        return {
+            primaryTermMonths: typeof parsed.primaryTermMonths === "number" ? parsed.primaryTermMonths : 36,
+            royaltyRate: typeof parsed.royaltyRate === "number" ? parsed.royaltyRate : 0.25,
+            expiryRisk: parsed.expiryRisk as LeaseAnalysis["expiryRisk"],
+            hasDepthSeverance: parsed.hasDepthSeverance ?? false,
+            hasAcreageLimitation: parsed.hasAcreageLimitation ?? false,
+            hasShutInProvisions: parsed.hasShutInProvisions ?? true,
+            notes: parsed.notes ?? "",
+        };
+    } catch {
+        return deriveLeaseAnalysis(primaryTerm, county, examPeriod);
+    }
+}

--- a/servers/title/src/tools/ownership.ts
+++ b/servers/title/src/tools/ownership.ts
@@ -1,0 +1,98 @@
+/**
+ * Ownership analysis — Working Interest (WI) and Net Revenue Interest (NRI) calculations.
+ *
+ * WI is the cost-bearing share of production. NRI is the revenue share after deducting
+ * lessor royalty and any overriding royalty interests (ORRI). The relationship is:
+ *   NRI = WI × (1 − royaltyRate − orriRate)
+ *
+ * Industry norms vary by basin: Permian Basin royalties run 20–25%; DJ Basin 18.75%; mid-continent 12.5–16.67%.
+ */
+
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface OwnershipBreakdown {
+    workingInterest: number; // fraction, e.g. 0.75 = 75% WI
+    netRevenueInterest: number; // fraction — revenue share after royalty and ORRI deductions
+    royaltyRate: number; // lessor royalty fraction
+    orriRate: number; // overriding royalty interest fraction
+    operatorWI: number; // operator's portion of WI
+    notes: string;
+}
+
+/** NRI = WI × (1 − royalty − ORRI). All inputs are fractions (0–1). */
+export function calculateNRI(workingInterest: number, royaltyRate: number, orriRate: number): number {
+    return workingInterest * (1 - royaltyRate - orriRate);
+}
+
+/**
+ * Rule-based ownership estimate — deterministic fallback when the API is unavailable.
+ * Basin defaults derived from public lease data and regional norms.
+ */
+export function deriveOwnershipBreakdown(propertyDescription: string, county: string): OwnershipBreakdown {
+    const lc = county.toLowerCase();
+    const isPermian = ["reeves", "midland", "ector", "andrews", "lea", "eddy", "loving"].some((c) => lc.includes(c));
+    const isDJ = ["weld", "adams", "arapahoe", "boulder"].some((c) => lc.includes(c));
+
+    const royaltyRate = isPermian ? 0.25 : isDJ ? 0.1875 : 0.1667;
+    const hasOrri = propertyDescription.toLowerCase().includes("override") || propertyDescription.toLowerCase().includes("orri");
+    const orriRate = hasOrri ? 0.02 : 0;
+
+    // Multi-parcel descriptions often indicate fractional WI (e.g. jointly owned section)
+    const workingInterest = propertyDescription.includes(",") ? 0.75 : 1.0;
+
+    const basin = isPermian ? "Permian Basin" : isDJ ? "DJ Basin" : "regional";
+
+    return {
+        workingInterest,
+        netRevenueInterest: calculateNRI(workingInterest, royaltyRate, orriRate),
+        royaltyRate,
+        orriRate,
+        operatorWI: workingInterest,
+        notes: `${basin} standard royalty ${(royaltyRate * 100).toFixed(2)}%${hasOrri ? `, plus ORRI ${(orriRate * 100).toFixed(2)}%` : ""}`,
+    };
+}
+
+export async function synthesizeOwnershipWithLLM(params: {
+    propertyDescription: string;
+    county: string;
+    state: string;
+}): Promise<OwnershipBreakdown> {
+    const { propertyDescription, county, state } = params;
+
+    const prompt = `You are Titulus Verificatus, a master oil & gas title analyst.
+
+Estimate the ownership structure for this property and return valid JSON only.
+
+PROPERTY:
+Description: ${propertyDescription}
+County: ${county}, ${state}
+
+Return ONLY valid JSON in this exact shape:
+{
+  "workingInterest": <fraction 0–1>,
+  "netRevenueInterest": <fraction 0–1>,
+  "royaltyRate": <fraction 0–1>,
+  "orriRate": <fraction 0–1>,
+  "operatorWI": <fraction 0–1>,
+  "notes": "<one sentence on key ownership consideration>"
+}
+
+Use realistic values for ${county} County, ${state}. Working interest and royalty rates must be consistent (NRI = WI × (1 − royalty − ORRI)).`;
+
+    try {
+        const raw = await callLLM({ prompt, maxTokens: 300 });
+        const match = raw.match(/\{[\s\S]*\}/);
+        if (!match) throw new Error("No JSON in response");
+        const parsed = JSON.parse(match[0]) as Partial<OwnershipBreakdown>;
+        return {
+            workingInterest: typeof parsed.workingInterest === "number" ? parsed.workingInterest : 1.0,
+            netRevenueInterest: typeof parsed.netRevenueInterest === "number" ? parsed.netRevenueInterest : 0.75,
+            royaltyRate: typeof parsed.royaltyRate === "number" ? parsed.royaltyRate : 0.25,
+            orriRate: typeof parsed.orriRate === "number" ? parsed.orriRate : 0,
+            operatorWI: typeof parsed.operatorWI === "number" ? parsed.operatorWI : 1.0,
+            notes: parsed.notes ?? "",
+        };
+    } catch {
+        return deriveOwnershipBreakdown(propertyDescription, county);
+    }
+}

--- a/servers/title/tests/tools.test.ts
+++ b/servers/title/tests/tools.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert";
+import { calculateNRI, deriveOwnershipBreakdown } from "../src/tools/ownership.js";
+import { deriveLeaseAnalysis, parseLeaseTermMonths } from "../src/tools/lease-analysis.js";
+import { calculateTotalBurden, deriveBurdenAssessment } from "../src/tools/burden-check.js";
+import { assessChainRisk, deriveChainOfTitle } from "../src/tools/chain-of-title.js";
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void | Promise<void>): Promise<void> {
+    return Promise.resolve()
+        .then(fn)
+        .then(() => {
+            console.log(`  ✓ ${name}`);
+            passed++;
+        })
+        .catch((err: unknown) => {
+            console.log(`  ✗ ${name}\n    ${err instanceof Error ? err.message : String(err)}`);
+            failed++;
+        });
+}
+
+// ── ownership ─────────────────────────────────────────────────────────────────
+
+await test("calculateNRI: standard Permian 25% royalty, no ORRI", () => {
+    const nri = calculateNRI(1.0, 0.25, 0);
+    assert.strictEqual(nri, 0.75);
+});
+
+await test("calculateNRI: fractional WI with ORRI reduces NRI correctly", () => {
+    const nri = calculateNRI(0.75, 0.25, 0.02);
+    // 0.75 × (1 − 0.25 − 0.02) = 0.75 × 0.73 = 0.5475
+    assert.ok(Math.abs(nri - 0.5475) < 1e-10, `expected 0.5475, got ${nri}`);
+});
+
+await test("deriveOwnershipBreakdown: Permian county uses 25% royalty", () => {
+    const result = deriveOwnershipBreakdown("Section 12 Block A", "Reeves");
+    assert.strictEqual(result.royaltyRate, 0.25);
+    assert.strictEqual(result.workingInterest, 1.0);
+    // NRI must equal WI × (1 − royalty − ORRI)
+    const expectedNRI = calculateNRI(result.workingInterest, result.royaltyRate, result.orriRate);
+    assert.ok(Math.abs(result.netRevenueInterest - expectedNRI) < 1e-10);
+});
+
+await test("deriveOwnershipBreakdown: multi-parcel description reduces WI", () => {
+    const multi = deriveOwnershipBreakdown("Section 1, Section 2, Section 3", "Midland");
+    const single = deriveOwnershipBreakdown("Section 12 Block A", "Midland");
+    assert.ok(multi.workingInterest < single.workingInterest);
+});
+
+await test("deriveOwnershipBreakdown: ORRI detected in description", () => {
+    const result = deriveOwnershipBreakdown("Section 5 with ORRI override", "Lea");
+    assert.ok(result.orriRate > 0);
+});
+
+// ── lease-analysis ────────────────────────────────────────────────────────────
+
+await test("parseLeaseTermMonths: year string parsed correctly", () => {
+    assert.strictEqual(parseLeaseTermMonths("3 years"), 36);
+    assert.strictEqual(parseLeaseTermMonths("2 year"), 24);
+    assert.strictEqual(parseLeaseTermMonths("5 Years"), 60);
+});
+
+await test("parseLeaseTermMonths: month string parsed correctly", () => {
+    assert.strictEqual(parseLeaseTermMonths("18 months"), 18);
+    assert.strictEqual(parseLeaseTermMonths("24 month"), 24);
+});
+
+await test("parseLeaseTermMonths: unparseable defaults to 36", () => {
+    assert.strictEqual(parseLeaseTermMonths("unknown"), 36);
+    assert.strictEqual(parseLeaseTermMonths(""), 36);
+});
+
+await test("deriveLeaseAnalysis: <24 months is high expiry risk", () => {
+    const result = deriveLeaseAnalysis("18 months", "Reeves", "20 years");
+    assert.strictEqual(result.expiryRisk, "high");
+    assert.strictEqual(result.primaryTermMonths, 18);
+});
+
+await test("deriveLeaseAnalysis: >36 months is low expiry risk", () => {
+    const result = deriveLeaseAnalysis("5 years", "Midland", "20 years");
+    assert.strictEqual(result.expiryRisk, "low");
+    assert.strictEqual(result.primaryTermMonths, 60);
+});
+
+await test("deriveLeaseAnalysis: notes include county name", () => {
+    const result = deriveLeaseAnalysis("3 years", "Weld", "20 years");
+    assert.ok(result.notes.includes("Weld"));
+});
+
+// ── burden-check ──────────────────────────────────────────────────────────────
+
+await test("calculateTotalBurden: royalty + ORRI sums correctly", () => {
+    const burden = calculateTotalBurden(0.25, 0.02);
+    assert.ok(Math.abs(burden - 0.27) < 1e-10);
+});
+
+await test("calculateTotalBurden: no ORRI returns just royalty", () => {
+    const burden = calculateTotalBurden(0.1875, 0);
+    assert.strictEqual(burden, 0.1875);
+});
+
+await test("deriveBurdenAssessment: ORRI keyword triggers nonzero orriRate", () => {
+    const result = deriveBurdenAssessment("Section 5 with ORRI", "Reeves");
+    assert.ok(result.orriRate > 0);
+    assert.ok(result.totalBurdenFraction > 0.25);
+});
+
+await test("deriveBurdenAssessment: simple Permian property is low risk", () => {
+    const result = deriveBurdenAssessment("Section 12 Block A", "Midland");
+    assert.strictEqual(result.riskLevel, "low");
+    assert.strictEqual(result.orriRate, 0);
+});
+
+await test("deriveBurdenAssessment: multi-parcel increases encumbrance count", () => {
+    const multi = deriveBurdenAssessment("Section 1, Section 2", "Reeves");
+    const single = deriveBurdenAssessment("Section 12", "Reeves");
+    assert.ok(multi.encumbranceCount >= single.encumbranceCount);
+});
+
+// ── chain-of-title ────────────────────────────────────────────────────────────
+
+await test("assessChainRisk: zero gaps = low risk regardless of exam period", () => {
+    assert.strictEqual(assessChainRisk(20, 0), "low");
+    assert.strictEqual(assessChainRisk(50, 0), "low");
+});
+
+await test("assessChainRisk: 1–2 gaps = medium risk", () => {
+    assert.strictEqual(assessChainRisk(20, 1), "medium");
+    assert.strictEqual(assessChainRisk(40, 2), "medium");
+});
+
+await test("assessChainRisk: >2 gaps = high risk", () => {
+    assert.strictEqual(assessChainRisk(20, 3), "high");
+});
+
+await test("deriveChainOfTitle: simple property has continuous chain", () => {
+    const result = deriveChainOfTitle("20 years", "Midland", "Section 12 Block A");
+    assert.strictEqual(result.gapsFound, 0);
+    assert.strictEqual(result.continuousChain, true);
+    assert.deepStrictEqual(result.curative, []);
+});
+
+await test("deriveChainOfTitle: complex/long exam produces gap and curative", () => {
+    const result = deriveChainOfTitle("40 years", "Reeves", "Section 1, Section 2, Section 3");
+    assert.ok(result.gapsFound > 0);
+    assert.strictEqual(result.continuousChain, false);
+    assert.ok(result.curative.length > 0);
+    assert.ok(result.curative[0].toLowerCase().includes("reeves"));
+});
+
+await test("deriveChainOfTitle: oldestRecordYear is approximately currentYear - examYears", () => {
+    const currentYear = new Date().getFullYear();
+    const result = deriveChainOfTitle("20 years", "Midland", "Section 5");
+    assert.strictEqual(result.oldestRecordYear, currentYear - 20);
+});
+
+console.log(`\n  Results: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

- **Step A** — `servers/title/src/tools/` split into 4 focused domain modules replacing the single monolithic `examine_title` tool:
  - `ownership.ts` — WI/NRI calculations (`calculateNRI`, `deriveOwnershipBreakdown`, `synthesizeOwnershipWithLLM`)
  - `lease-analysis.ts` — lease term parsing (`parseLeaseTermMonths`, `deriveLeaseAnalysis`, `synthesizeLeaseAnalysisWithLLM`)
  - `burden-check.ts` — ORRI/encumbrance identification (`calculateTotalBurden`, `deriveBurdenAssessment`, `synthesizeBurdenCheckWithLLM`)
  - `chain-of-title.ts` — conveyance chain validation (`assessChainRisk`, `deriveChainOfTitle`, `synthesizeChainOfTitleWithLLM`)
  - `index.ts` thin facade now exposes 4 MCP tools: `examine_ownership`, `analyze_lease`, `check_burdens`, `trace_chain_of_title`
  - `tests/tools.test.ts` — 22 domain logic tests (NRI formula, lease term parsing, burden totals, chain risk scoring)

- **Step B** — `agents/title-analyst/src/agent/` full implementation replacing the stub:
  - `title-client.ts` — MCP HTTP client with Timeout Boundary, Error Classification, Recovery Guide (Arcade patterns)
  - `index.ts` — `titleAnalystManifest` (4 tools, port 3010), `titleAnalystConfig`, `createTitleAnalystRuntime/Endpoint`, `runTitleAnalystTask()` Layer 2 LLM execution loop
  - `tests/mcp-client.test.ts` — 13 tests (Layer 1 client + Layer 2 runTask)
  - `tests/agent.test.ts` — 31 contract tests (manifest validation, discovery, HITL, evals, scope enforcement, blocking eval halt)

## Test plan

- [x] `servers/title` — `tests/tools.test.ts`: 22/22 passed
- [x] `servers/title` — `tests/server.test.ts`: 3/3 passed (backward compat preserved)
- [x] `agents/title-analyst` — `tests/mcp-client.test.ts`: 13/13 passed
- [x] `agents/title-analyst` — `tests/agent.test.ts`: 31/31 passed
- [x] `pnpm turbo build` — both packages build clean
- [x] `pnpm turbo test --filter=@shaleyeah/server-title --filter=@shaleyeah/title-analyst` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)