### PR TITLE
feat(infrastructure): split server into 4 domain modules + infrastructure-planner agent (#375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **infrastructure / infrastructure-planner pair — Steps A + B** (#375) — Full Tier 1 server modularization and Tier 2 agent implementation for O&G infrastructure planning.
+  - `servers/infrastructure/src/tools/` — 4 focused modules (pipeline, facilities, cost-estimation, compliance) with LLM synthesis + deterministic fallbacks; `tests/tools.test.ts` (28 tests)
+  - `agents/infrastructure-planner/src/agent/` — manifest (4 tools, port 3012), runtime config, `runInfrastructurePlannerTask()` Layer 2 loop, infrastructure MCP HTTP client; `tests/mcp-client.test.ts` (12) + `tests/agent.test.ts` (31)
+
 - **title / title-analyst pair — Steps A + B** (#372) — Full Tier 1 server modularization and Tier 2 agent implementation for oil & gas title analysis.
   - `servers/title/src/tools/` — 4 focused modules (ownership, lease-analysis, burden-check, chain-of-title) with LLM synthesis + deterministic fallbacks; `tests/tools.test.ts` (22 tests)
   - `agents/title-analyst/src/agent/` — manifest (4 tools, port 3010), runtime config, `runTitleAnalystTask()` Layer 2 loop, title MCP HTTP client; `tests/mcp-client.test.ts` (13) + `tests/agent.test.ts` (31)

--- a/agents/infrastructure-planner/CHANGELOG.md
+++ b/agents/infrastructure-planner/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog — @shaleyeah/infrastructure-planner
+
+## [Unreleased]
+
+### Added
+
+- **Step B: Tier 2 agent implementation** (#375) — Full infrastructure-planner agent replacing the stub:
+  - `src/agent/infrastructure-client.ts` — MCP HTTP client with Timeout Boundary, Recovery Guide, and Error Classification Arcade patterns
+  - `src/agent/index.ts` — `infrastructurePlannerManifest` (4 tools), `infrastructurePlannerConfig` (port 3012), `createInfrastructurePlannerRuntime()`, `createInfrastructurePlannerEndpoint()`, `runInfrastructurePlannerTask()` (Layer 2 LLM execution loop)
+  - `tests/mcp-client.test.ts` — 12 tests for Layer 1 client and Layer 2 runTask loop
+  - `tests/agent.test.ts` — 31 contract tests: manifest/config validation, progressive discovery, model routing, HITL, evals, health endpoint, scope enforcement, blocking eval halt, invalid manifest rejection
+
+## [0.1.0] — 2026-06-04
+
+### Added
+
+- Initial package stub created during monorepo conversion (#385)

--- a/agents/infrastructure-planner/package.json
+++ b/agents/infrastructure-planner/package.json
@@ -1,19 +1,25 @@
 {
   "name": "@shaleyeah/infrastructure-planner",
   "version": "0.1.0",
-  "description": "Infrastructure Planner — Tier 2 intelligence layer for infrastructure assessment",
+  "description": "Infrastructure Planner — Tier 2 intelligence layer for infrastructure planning",
   "private": true,
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/agent/index.js",
   "scripts": {
     "build": "tsc",
+    "start": "tsx src/agent/index.ts",
+    "test": "bash ../../scripts/run-tests.sh",
+    "lint": "biome check .",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@shaleyeah/sdk": "workspace:*"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.11",
     "@types/node": "^25.6.0",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.2"
   }
 }

--- a/agents/infrastructure-planner/src/agent/index.ts
+++ b/agents/infrastructure-planner/src/agent/index.ts
@@ -1,0 +1,385 @@
+import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
+import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import { callInfrastructureTool } from "./infrastructure-client.js";
+
+export { callInfrastructureTool };
+
+// ── Manifest ──────────────────────────────────────────────────────────────────
+
+export const infrastructurePlannerManifest: AgentManifest = {
+    id: "infrastructure-planner",
+    role: "infrastructure-planning",
+    version: "0.1.0",
+    description:
+        "Plans gathering pipelines, surface facilities, capital costs, and permitting for O&G development projects",
+    persona: {
+        name: "Structura Ingenious",
+        role: "Master Infrastructure Architect",
+        expertise: [
+            "Pipeline and gathering system design",
+            "Surface facility sizing and layout",
+            "Infrastructure CAPEX estimation",
+            "Permitting and regulatory compliance",
+            "Midstream takeaway capacity planning",
+        ],
+    },
+    capabilities: [
+        "pipeline-planning",
+        "facility-sizing",
+        "cost-estimation",
+        "compliance-assessment",
+    ],
+    tools: [
+        {
+            name: "infrastructure-planner.plan_pipeline",
+            description:
+                "Plan gathering and transmission pipeline infrastructure — routing, capacity, and takeaway risk",
+            type: "query",
+            capabilities: ["pipeline-planning"],
+            inputSchema: {
+                type: "object",
+                properties: {
+                    wellCount: { type: "number", description: "Number of wells to connect" },
+                    expectedProduction: { type: "number", description: "Expected total production in BOPD" },
+                    location: { type: "string", description: "Project location (state, basin, or county)" },
+                },
+                required: ["wellCount", "expectedProduction", "location"],
+            },
+            readOnly: true,
+            destructive: false,
+            requiresHumanApproval: false,
+            requiredScopes: ["read:infrastructure"],
+            modelRequirement: "standard-analysis",
+            evalProfile: "infrastructure-planner-pipeline",
+            mcpServer: "infrastructure",
+        },
+        {
+            name: "infrastructure-planner.size_facilities",
+            description:
+                "Size surface facilities — batteries, separators, compressors, and salt water disposal wells",
+            type: "query",
+            capabilities: ["facility-sizing"],
+            inputSchema: {
+                type: "object",
+                properties: {
+                    wellCount: { type: "number", description: "Number of wells" },
+                    expectedProduction: { type: "number", description: "Expected total production in BOPD" },
+                    location: { type: "string", description: "Project location" },
+                },
+                required: ["wellCount", "expectedProduction", "location"],
+            },
+            readOnly: true,
+            destructive: false,
+            requiresHumanApproval: false,
+            requiredScopes: ["read:infrastructure"],
+            modelRequirement: "standard-analysis",
+            evalProfile: "infrastructure-planner-facilities",
+            mcpServer: "infrastructure",
+        },
+        {
+            name: "infrastructure-planner.estimate_costs",
+            description:
+                "Estimate infrastructure CAPEX — pipelines, facilities, compression, and SWD wells",
+            type: "query",
+            capabilities: ["cost-estimation"],
+            inputSchema: {
+                type: "object",
+                properties: {
+                    wellCount: { type: "number", description: "Number of wells" },
+                    compressors: { type: "number", description: "Number of compressor units required" },
+                    swdWells: { type: "number", description: "Number of salt water disposal wells required" },
+                    location: { type: "string", description: "Project location" },
+                },
+                required: ["wellCount", "compressors", "swdWells", "location"],
+            },
+            readOnly: true,
+            destructive: false,
+            requiresHumanApproval: false,
+            requiredScopes: ["read:infrastructure"],
+            modelRequirement: "standard-analysis",
+            evalProfile: "infrastructure-planner-costs",
+            mcpServer: "infrastructure",
+        },
+        {
+            name: "infrastructure-planner.assess_compliance",
+            description:
+                "Assess permitting and regulatory compliance requirements — permits, timeline, and environmental risks",
+            type: "query",
+            capabilities: ["compliance-assessment"],
+            inputSchema: {
+                type: "object",
+                properties: {
+                    wellCount: { type: "number", description: "Number of wells" },
+                    location: { type: "string", description: "Project location (state, basin, or county)" },
+                    environmentalConstraints: {
+                        type: "array",
+                        items: { type: "string" },
+                        description: "Known environmental constraints or sensitivities",
+                    },
+                },
+                required: ["wellCount", "location"],
+            },
+            readOnly: true,
+            destructive: false,
+            requiresHumanApproval: false,
+            requiredScopes: ["read:infrastructure"],
+            modelRequirement: "standard-analysis",
+            evalProfile: "infrastructure-planner-compliance",
+            mcpServer: "infrastructure",
+        },
+    ],
+    requiredScopes: ["read:infrastructure"],
+    providerRequirements: [
+        { type: "llm", required: true, description: "Anthropic Claude — standard analysis" },
+    ],
+    compatibility: {
+        agentRuntime: "^0.1.0",
+        remoteEndpoint: "^0.1.0",
+        mcp: "2025-03",
+    },
+    health: {
+        readinessChecks: ["manifest", "runtime-config", "tool-handlers", "model-routing"],
+    },
+    memory: {
+        namespace: "infrastructure-planner",
+        reviewRequired: true,
+        sharedMemoryOptIn: false,
+    },
+    evals: {
+        defaultProfile: "infrastructure-planner-default",
+        requiredChecks: ["schema", "redactSecrets"],
+    },
+    autonomy: {
+        defaultLevel: "assistive",
+        allowedLevels: ["assistive", "reviewed"],
+    },
+};
+
+// ── Runtime config ────────────────────────────────────────────────────────────
+
+export const infrastructurePlannerConfig: AgentRuntimeConfig = {
+    autonomy: "assistive",
+    modelRouting: {
+        "small-fast": { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+        "standard-analysis": { provider: "anthropic", model: "claude-sonnet-4-6" },
+        "deep-reasoning": { provider: "anthropic", model: "claude-opus-4-8" },
+        "local-private": { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+        deterministic: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+    },
+    hitl: {
+        approvalMode: "when-sensitive",
+        requireForDestructive: true,
+        requireForMemoryPromotion: true,
+    },
+    evals: {
+        enabled: true,
+        profile: "infrastructure-planner-default",
+        checks: {
+            schema: "blocking",
+            domainCompleteness: "advisory",
+            confidenceMinimum: 0.7,
+            requireSources: false,
+            redactSecrets: "blocking",
+            memoryPromotion: "reviewed-only",
+        },
+    },
+    memory: {
+        enabled: true,
+        namespace: "infrastructure-planner",
+        vectorStore: { enabled: false },
+        retentionDays: 30,
+        promotion: { requireHumanReview: true, allowSharedMemory: false },
+    },
+    mcpServers: {
+        infrastructure: {
+            url: process.env.INFRASTRUCTURE_MCP_URL ?? "http://localhost:3012",
+            transport: "http",
+            authType: "none",
+        },
+    },
+    dataConnectors: {},
+};
+
+// ── URL helper ────────────────────────────────────────────────────────────────
+
+function infrastructureUrl(config: AgentRuntimeConfig): string {
+    return config.mcpServers?.["infrastructure"]?.url ?? "http://localhost:3012";
+}
+
+// ── Handler map ───────────────────────────────────────────────────────────────
+
+const handlers: Record<string, StandaloneToolHandler> = {
+    "infrastructure-planner.plan_pipeline": ({ args, config }) =>
+        callInfrastructureTool(infrastructureUrl(config), "plan_pipeline", args as Record<string, unknown>),
+    "infrastructure-planner.size_facilities": ({ args, config }) =>
+        callInfrastructureTool(infrastructureUrl(config), "size_facilities", args as Record<string, unknown>),
+    "infrastructure-planner.estimate_costs": ({ args, config }) =>
+        callInfrastructureTool(infrastructureUrl(config), "estimate_costs", args as Record<string, unknown>),
+    "infrastructure-planner.assess_compliance": ({ args, config }) =>
+        callInfrastructureTool(infrastructureUrl(config), "assess_compliance", args as Record<string, unknown>),
+};
+
+// ── Runtime + Endpoint factories ──────────────────────────────────────────────
+
+export function createInfrastructurePlannerRuntime(
+    config: AgentRuntimeConfig = infrastructurePlannerConfig,
+): LocalAgentRuntime {
+    return new LocalAgentRuntime({ manifest: infrastructurePlannerManifest, config, handlers });
+}
+
+export function createInfrastructurePlannerEndpoint(
+    config: AgentRuntimeConfig = infrastructurePlannerConfig,
+): LocalAgentEndpoint {
+    return new LocalAgentEndpoint(createInfrastructurePlannerRuntime(config));
+}
+
+// ── Task execution loop (Layer 2) ─────────────────────────────────────────────
+
+/**
+ * Run a multi-step infrastructure planning task driven by the LLM.
+ *
+ * All tool calls route through LocalAgentRuntime.execute() — HITL gate, scope
+ * checks, and audit logging fire on every step (Arcade #46: Permission Gate).
+ *
+ * Deferred (#395): Context Injection — read/write memory namespace around the loop.
+ * Deferred (#396): Async Job — polling for long-running tools.
+ */
+export async function runInfrastructurePlannerTask(
+    goal: string,
+    options: {
+        config?: AgentRuntimeConfig;
+        apiKey?: string;
+        runtime?: LocalAgentRuntime;
+        onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+    } = {},
+): Promise<string> {
+    const config = options.config ?? infrastructurePlannerConfig;
+
+    let runtime = options.runtime;
+    let ownedRuntime = false;
+    if (!runtime) {
+        runtime = createInfrastructurePlannerRuntime(config);
+        await runtime.initialize();
+        ownedRuntime = true;
+    }
+
+    try {
+        return await executeLoop(goal, runtime, options);
+    } finally {
+        if (ownedRuntime) await runtime.shutdown();
+    }
+}
+
+function buildTranscript(history: Array<{ role: "user" | "assistant" | "tool"; content: string }>): string {
+    return history
+        .map((t) => {
+            if (t.role === "user") return `User: ${t.content}`;
+            if (t.role === "assistant") return `Assistant: ${t.content}`;
+            return `Tool result: ${t.content}`;
+        })
+        .join("\n\n");
+}
+
+function parseJson(
+    text: string,
+): { action?: string; tool?: string; args?: Record<string, unknown>; answer?: string } | null {
+    try {
+        const cleaned = text
+            .replace(/^```(?:json)?\s*/m, "")
+            .replace(/\s*```\s*$/m, "")
+            .trim();
+        return JSON.parse(cleaned);
+    } catch {
+        return null;
+    }
+}
+
+async function executeLoop(
+    goal: string,
+    runtime: LocalAgentRuntime,
+    options: {
+        apiKey?: string;
+        onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+    },
+): Promise<string> {
+    const toolDefs = infrastructurePlannerManifest.tools
+        .map((t) => `  ${t.name}: ${t.description}`)
+        .join("\n");
+
+    const system = `You are ${infrastructurePlannerManifest.persona.name}, ${infrastructurePlannerManifest.persona.role}.
+
+Available tools:
+${toolDefs}
+
+Respond ONLY with valid JSON — no prose, no markdown. Two formats allowed:
+1. Call a tool:  {"action":"tool","tool":"<full tool name>","args":{...}}
+2. Final answer: {"action":"done","answer":"<synthesized answer>"}
+
+Always use the full tool name (e.g. "infrastructure-planner.plan_pipeline").
+If you cannot complete the task with the available tools, respond with {"action":"done","answer":"<explanation>"}.`;
+
+    type Turn = { role: "user" | "assistant" | "tool"; content: string };
+    const history: Turn[] = [{ role: "user", content: goal }];
+    const MAX_STEPS = 8;
+
+    for (let step = 0; step < MAX_STEPS; step++) {
+        const response = await callLLM({
+            system,
+            prompt: `${buildTranscript(history)}\n\nAssistant:`,
+            apiKey: options.apiKey,
+        });
+
+        history.push({ role: "assistant", content: response });
+
+        const parsed = parseJson(response);
+        if (!parsed || parsed.action === "done" || !parsed.tool) {
+            return parsed?.answer ?? response;
+        }
+
+        const execResult = await runtime.execute({
+            toolName: parsed.tool,
+            args: parsed.args ?? {},
+            runId: `task:step:${step}`,
+        });
+
+        if (execResult.status === "completed") {
+            history.push({ role: "tool", content: JSON.stringify(execResult.data) });
+        } else if (execResult.status === "approval_required") {
+            if (!options.onApprovalRequired) {
+                throw new Error(
+                    `Tool ${parsed.tool} requires human approval. ` +
+                        "Provide an onApprovalRequired callback to runInfrastructurePlannerTask, or set autonomy to 'autonomous'.",
+                );
+            }
+            const approval = await options.onApprovalRequired(execResult.challenge);
+            const approved = await runtime.execute({
+                toolName: parsed.tool,
+                args: parsed.args ?? {},
+                approval,
+                runId: `task:step:${step}:approved`,
+            });
+            if (approved.status === "completed") {
+                history.push({ role: "tool", content: JSON.stringify(approved.data) });
+            } else {
+                const err = approved.status === "failed" ? approved.error : "approval re-execution failed";
+                history.push({ role: "tool", content: `Error after approval for ${parsed.tool}: ${err}` });
+            }
+        } else {
+            const hint = execResult.retryable
+                ? " (retryable — server may be temporarily unavailable)"
+                : " (permanent)";
+            history.push({
+                role: "tool",
+                content: `Error calling ${parsed.tool}: ${execResult.error}${hint}`,
+            });
+        }
+    }
+
+    const finalResponse = await callLLM({
+        system,
+        prompt: `${buildTranscript(history)}\n\nUser: Maximum steps reached. Synthesize findings now.\n\nAssistant:`,
+        apiKey: options.apiKey,
+    });
+
+    return parseJson(finalResponse)?.answer ?? finalResponse;
+}

--- a/agents/infrastructure-planner/src/agent/infrastructure-client.ts
+++ b/agents/infrastructure-planner/src/agent/infrastructure-client.ts
@@ -1,0 +1,61 @@
+/**
+ * Infrastructure MCP client — thin wrapper that connects to the infrastructure Tier 1
+ * server over HTTP, calls a single tool, and closes the connection.
+ *
+ * Arcade patterns:
+ *   #28 Timeout Boundary    — configurable timeoutMs, default 30s
+ *   #39 Recovery Guide      — error messages include tool name and cause
+ *   #40 Error Classification — RetryableToolError vs PermanentToolError
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { PermanentToolError, RetryableToolError } from "@shaleyeah/sdk";
+
+export async function callInfrastructureTool(
+    url: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    options: { timeoutMs?: number } = {},
+): Promise<unknown> {
+    const timeoutMs = options.timeoutMs ?? 30_000;
+
+    const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(
+            () => reject(new RetryableToolError(`Tool call to ${toolName} timed out after ${timeoutMs}ms`)),
+            timeoutMs,
+        ),
+    );
+
+    const callPromise = (async () => {
+        const transport = new StreamableHTTPClientTransport(new URL(url));
+        const client = new Client({ name: "infrastructure-planner", version: "0.1.0" });
+        await client.connect(transport);
+        try {
+            const result = await client.callTool({ name: toolName, arguments: args });
+            return result.content;
+        } finally {
+            await client.close().catch(() => {});
+        }
+    })();
+
+    try {
+        return await Promise.race([callPromise, timeoutPromise]);
+    } catch (err) {
+        if (err instanceof RetryableToolError || err instanceof PermanentToolError) throw err;
+
+        const msg = err instanceof Error ? err.message : String(err);
+
+        if (/ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENETUNREACH|fetch failed/i.test(msg)) {
+            throw new RetryableToolError(
+                `Network error calling ${toolName}: ${msg}`,
+                err instanceof Error ? err : undefined,
+            );
+        }
+
+        throw new PermanentToolError(
+            `Tool call to ${toolName} failed: ${msg}`,
+            err instanceof Error ? err : undefined,
+        );
+    }
+}

--- a/agents/infrastructure-planner/src/index.ts
+++ b/agents/infrastructure-planner/src/index.ts
@@ -15,6 +15,4 @@
  */
 
 export const AGENT_ID = "infrastructure-planner";
-
-// Uncomment and switch to this export once src/agent/index.ts is implemented:
-// export * from "./agent/index.js";
+export * from "./agent/index.js";

--- a/agents/infrastructure-planner/tests/agent.test.ts
+++ b/agents/infrastructure-planner/tests/agent.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Infrastructure Planner Agent Contract Tests — Issue #375
+ *
+ * Proves the infrastructure server tools are accessible through the AgentRuntime
+ * contract and that the infrastructure-planner manifest satisfies all Arcade
+ * acceptance criteria.
+ */
+
+import { AgentManifestSchema, AgentRuntimeConfigSchema, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+    createInfrastructurePlannerEndpoint,
+    createInfrastructurePlannerRuntime,
+    infrastructurePlannerConfig,
+    infrastructurePlannerManifest,
+} from "../src/agent/index.js";
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, message: string): void {
+    if (condition) {
+        console.log(`  ✅ ${message}`);
+        passed++;
+    } else {
+        console.error(`  ❌ ${message}`);
+        failed++;
+    }
+}
+
+async function infrastructureServerReachable(): Promise<boolean> {
+    try {
+        const url = infrastructurePlannerConfig.mcpServers?.["infrastructure"]?.url ?? "http://localhost:3012";
+        const ctrl = new AbortController();
+        const timer = setTimeout(() => ctrl.abort(), 500);
+        await fetch(url, { method: "HEAD", signal: ctrl.signal });
+        clearTimeout(timer);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+console.log("🧪 Starting Infrastructure Planner Agent Contract Tests (#375)\n");
+
+console.log("📋 Testing manifest and config validation...");
+{
+    const manifest = AgentManifestSchema.safeParse(infrastructurePlannerManifest);
+    assert(manifest.success, "Infrastructure planner manifest validates");
+    if (!manifest.success) console.error("  ", manifest.error.format());
+
+    const config = AgentRuntimeConfigSchema.safeParse(infrastructurePlannerConfig);
+    assert(config.success, "Infrastructure planner runtime config validates");
+
+    assert(infrastructurePlannerManifest.tools.length === 4, "Infrastructure planner exposes 4 tools");
+    assert(
+        infrastructurePlannerManifest.tools.every((t) => t.name.startsWith("infrastructure-planner.")),
+        "All tools follow infrastructure-planner. naming convention",
+    );
+    assert(
+        infrastructurePlannerManifest.tools.every((t) => !t.modelRequirement.includes("claude")),
+        "Model requirements are capability labels, not provider names",
+    );
+    const allToolScopes = new Set(infrastructurePlannerManifest.tools.flatMap((t) => t.requiredScopes));
+    assert(
+        [...allToolScopes].every((s) => infrastructurePlannerManifest.requiredScopes.includes(s)),
+        "Manifest requiredScopes is a superset of all tool requiredScopes",
+    );
+    const llmReq = infrastructurePlannerManifest.providerRequirements.find((p) => p.type === "llm");
+    assert(llmReq?.required === true, "LLM provider requirement is marked required");
+}
+
+console.log("\n🔎 Testing progressive discovery...");
+{
+    const runtime = createInfrastructurePlannerRuntime();
+    await runtime.initialize();
+
+    const summary = runtime.discover("summary");
+    assert("capabilities" in summary, "Summary discovery returns capabilities");
+    assert(!("tools" in summary), "Summary discovery does not include tool list");
+
+    const tools = runtime.discover("tools");
+    assert(Array.isArray(tools) && tools.length === 4, "Tool discovery returns 4 tools");
+    assert(!("inputSchema" in tools[0]), "Tool list omits input schemas");
+
+    const schema = runtime.discover("schema", "infrastructure-planner.plan_pipeline");
+    assert(schema?.inputSchema !== undefined, "Schema discovery returns plan_pipeline input schema");
+    assert(
+        (schema?.inputSchema as Record<string, unknown>)?.required !== undefined,
+        "plan_pipeline schema declares required fields",
+    );
+
+    const missing = runtime.discover("schema", "infrastructure-planner.nonexistent");
+    assert(missing === null, "Schema discovery returns null for unknown tool");
+
+    await runtime.shutdown();
+}
+
+console.log("\n📡 Testing model capability routing...");
+{
+    const runtime = createInfrastructurePlannerRuntime();
+    await runtime.initialize();
+
+    const modelRequirements = new Set(infrastructurePlannerManifest.tools.map((t) => t.modelRequirement));
+    assert(modelRequirements.has("standard-analysis"), "standard-analysis requirement present in tool suite");
+
+    for (const req of modelRequirements) {
+        const binding = infrastructurePlannerConfig.modelRouting[req];
+        assert(binding !== undefined, `Model route exists for requirement: ${req}`);
+    }
+
+    await runtime.shutdown();
+}
+
+console.log("\n🙋 Testing HITL policy...");
+{
+    const live = await infrastructureServerReachable();
+
+    if (live) {
+        const runtime = createInfrastructurePlannerRuntime();
+        await runtime.initialize();
+
+        const result = await runtime.execute({
+            toolName: "infrastructure-planner.plan_pipeline",
+            args: { wellCount: 10, expectedProduction: 5000, location: "Reeves County, Texas" },
+        });
+        assert(result.status === "completed", "plan_pipeline completes without approval challenge");
+
+        await runtime.shutdown();
+    } else {
+        console.log("  ⚠️  [skipped] execute() test requires live infrastructure server");
+    }
+
+    const strictRuntime = createInfrastructurePlannerRuntime({
+        ...infrastructurePlannerConfig,
+        hitl: { ...infrastructurePlannerConfig.hitl, approvalMode: "always" },
+    });
+    await strictRuntime.initialize();
+    const blocked = await strictRuntime.execute({
+        toolName: "infrastructure-planner.plan_pipeline",
+        args: { wellCount: 10, expectedProduction: 5000, location: "Reeves County, Texas" },
+    });
+    assert(blocked.status === "approval_required", "approvalMode: 'always' blocks all tools");
+    if (blocked.status === "approval_required") {
+        assert(blocked.challenge.type === "human_approval_required", "Challenge is structured");
+        assert(
+            blocked.challenge.agentId === "infrastructure-planner",
+            "Challenge identifies infrastructure-planner agent",
+        );
+    }
+
+    await strictRuntime.shutdown();
+}
+
+console.log("\n🧪 Testing evals policy...");
+{
+    const live = await infrastructureServerReachable();
+    if (!live) {
+        console.log("  ⚠️  [skipped] eval test requires live infrastructure server");
+    } else {
+        const runtime = createInfrastructurePlannerRuntime();
+        await runtime.initialize();
+
+        const result = await runtime.execute({
+            toolName: "infrastructure-planner.plan_pipeline",
+            args: { wellCount: 10, expectedProduction: 5000, location: "Reeves County, Texas" },
+        });
+
+        assert(result.status === "completed", "plan_pipeline completes for eval test");
+        if (result.status === "completed") {
+            assert(result.evals.some((e) => e.check === "schema"), "Schema eval ran");
+            assert(result.evals.some((e) => e.check === "redactSecrets"), "Secret-redaction eval ran");
+            assert(result.evals.every((e) => e.status === "pass"), "All evals pass on clean output");
+        }
+
+        await runtime.shutdown();
+    }
+}
+
+console.log("\n🏥 Testing health endpoint and standalone boot...");
+{
+    const endpoint = createInfrastructurePlannerEndpoint();
+    const health = await endpoint.health();
+    assert(health.agentId === "infrastructure-planner", "Health endpoint identifies infrastructure-planner");
+    assert(health.status !== "not_ready", "Infrastructure planner boots without external dependencies");
+
+    const manifest = await endpoint.manifest();
+    assert(manifest.id === "infrastructure-planner", "Endpoint exposes infrastructure-planner manifest");
+    assert(manifest.tools.length === 4, "Endpoint manifest has 4 tools");
+
+    const toolSchema = await endpoint.discoveryToolSchema("infrastructure-planner.size_facilities");
+    assert(toolSchema !== null, "Endpoint exposes tool schemas by name");
+}
+
+console.log("\n🔒 Testing scope enforcement...");
+{
+    const runtime = createInfrastructurePlannerRuntime();
+    await runtime.initialize();
+
+    const blocked = await runtime.execute({
+        toolName: "infrastructure-planner.plan_pipeline",
+        args: { wellCount: 10, expectedProduction: 5000, location: "Reeves County, Texas" },
+        grantedScopes: [],
+    });
+    assert(blocked.status === "failed", "Missing scope blocks tool execution");
+    if (blocked.status === "failed") {
+        assert(blocked.error.includes("Missing required scopes"), "Error message names missing scopes");
+    }
+
+    const allowed = await runtime.execute({
+        toolName: "infrastructure-planner.plan_pipeline",
+        args: { wellCount: 10, expectedProduction: 5000, location: "Reeves County, Texas" },
+        grantedScopes: ["read:infrastructure"],
+    });
+    assert(
+        allowed.status !== "failed" || !allowed.error.includes("Missing required scopes"),
+        "Correct scopes are accepted",
+    );
+
+    await runtime.shutdown();
+}
+
+console.log("\n🧱 Testing blocking eval halt...");
+{
+    const undefinedHandler = async () => undefined;
+    const allHandlers = Object.fromEntries(
+        infrastructurePlannerManifest.tools.map((t) => [t.name, undefinedHandler]),
+    );
+    const testRuntime = new LocalAgentRuntime({
+        manifest: infrastructurePlannerManifest,
+        config: infrastructurePlannerConfig,
+        handlers: allHandlers,
+    });
+    await testRuntime.initialize();
+    const result = await testRuntime.execute({
+        toolName: "infrastructure-planner.plan_pipeline",
+        args: { wellCount: 10, expectedProduction: 5000, location: "Reeves County, Texas" },
+    });
+    assert(result.status === "failed", "Blocking eval failure returns status: failed");
+    if (result.status === "failed") {
+        assert(result.error.includes("Blocking eval"), "Error message references blocking eval");
+        assert(result.retryable === false, "Blocking eval failures are not retryable");
+    }
+    await testRuntime.shutdown();
+}
+
+console.log("\n🛑 Testing invalid manifest fails early...");
+{
+    try {
+        new LocalAgentRuntime({
+            manifest: { ...infrastructurePlannerManifest, id: "" } as typeof infrastructurePlannerManifest,
+            config: infrastructurePlannerConfig,
+            handlers: Object.fromEntries(
+                infrastructurePlannerManifest.tools.map((t) => [t.name, async () => ({})]),
+            ),
+        });
+        assert(false, "Empty manifest id should fail validation");
+    } catch {
+        assert(true, "Invalid manifest id fails at construction");
+    }
+}
+
+console.log("\n══════════════════════════════════════════════");
+console.log(`Infrastructure Planner Agent Contract Tests: ${passed} passed, ${failed} failed`);
+console.log("══════════════════════════════════════════════");
+
+if (failed > 0) {
+    process.exit(1);
+}

--- a/agents/infrastructure-planner/tests/mcp-client.test.ts
+++ b/agents/infrastructure-planner/tests/mcp-client.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Infrastructure Planner MCP Client Tests — Issue #375
+ *
+ * Layer 1: callInfrastructureTool export, config shape, tool manifest declarations.
+ * Layer 2: runInfrastructurePlannerTask export, callLLM wiring, HITL contract.
+ */
+
+import assert from "node:assert";
+import { PermanentToolError, RetryableToolError } from "@shaleyeah/sdk";
+import {
+    callInfrastructureTool,
+    createInfrastructurePlannerRuntime,
+    infrastructurePlannerConfig,
+    infrastructurePlannerManifest,
+    runInfrastructurePlannerTask,
+} from "../src/agent/index.js";
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void | Promise<void>): Promise<void> {
+    return Promise.resolve()
+        .then(() => fn())
+        .then(() => {
+            console.log(`  ✅ ${name}`);
+            passed++;
+        })
+        .catch((err) => {
+            console.error(`  ❌ ${name}: ${err instanceof Error ? err.message : err}`);
+            failed++;
+        });
+}
+
+const LIVE_SERVER = await (async () => {
+    try {
+        const url = infrastructurePlannerConfig.mcpServers?.["infrastructure"]?.url ?? "http://localhost:3012";
+        const ctrl = new AbortController();
+        const timer = setTimeout(() => ctrl.abort(), 500);
+        await fetch(url, { method: "HEAD", signal: ctrl.signal });
+        clearTimeout(timer);
+        return true;
+    } catch {
+        return false;
+    }
+})();
+
+console.log("🧪 Starting Infrastructure Planner MCP Client Tests (#375)\n");
+
+console.log("📦 Layer 1 — callInfrastructureTool export and config...");
+await test("callInfrastructureTool is exported", () => {
+    assert.strictEqual(typeof callInfrastructureTool, "function");
+});
+
+await test("infrastructure server URL defaults to localhost:3012", () => {
+    const url = infrastructurePlannerConfig.mcpServers?.["infrastructure"]?.url;
+    assert.strictEqual(url, "http://localhost:3012");
+});
+
+await test("infrastructure server transport is http", () => {
+    const transport = infrastructurePlannerConfig.mcpServers?.["infrastructure"]?.transport;
+    assert.strictEqual(transport, "http");
+});
+
+await test("all 4 infrastructure-planner tools declare mcpServer: 'infrastructure'", () => {
+    const all = infrastructurePlannerManifest.tools.every((t) => t.mcpServer === "infrastructure");
+    assert.ok(all, "Every tool must point to the infrastructure server");
+});
+
+await test("standard-analysis model requirement uses real model", () => {
+    const binding = infrastructurePlannerConfig.modelRouting["standard-analysis"];
+    assert.ok(binding?.model.includes("claude"), "Must reference a real Claude model");
+});
+
+await test("callInfrastructureTool throws RetryableToolError for unreachable server", async () => {
+    try {
+        await callInfrastructureTool("http://localhost:19999/transport", "plan_pipeline", {
+            wellCount: 10,
+            expectedProduction: 5000,
+            location: "Reeves County, Texas",
+        });
+        assert.fail("Should have thrown");
+    } catch (err) {
+        assert.ok(
+            err instanceof RetryableToolError,
+            `Expected RetryableToolError, got: ${err instanceof Error ? err.constructor.name : err}`,
+        );
+    }
+});
+
+console.log("\n🔄 Layer 2 — runInfrastructurePlannerTask export and LLM wiring...");
+await test("runInfrastructurePlannerTask is exported", () => {
+    assert.strictEqual(typeof runInfrastructurePlannerTask, "function");
+});
+
+await test("runInfrastructurePlannerTask throws without API key", async () => {
+    const origKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = "";
+    try {
+        await runInfrastructurePlannerTask("Plan pipeline for 10 wells in Reeves County, Texas");
+        assert.fail("Should have thrown");
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        assert.ok(
+            msg.toLowerCase().includes("anthropic_api_key") ||
+                msg.toLowerCase().includes("api key") ||
+                msg.toLowerCase().includes("api_key") ||
+                msg.toLowerCase().includes("authentication") ||
+                msg.toLowerCase().includes("unauthorized"),
+            `Expected auth-related error, got: ${msg}`,
+        );
+    } finally {
+        if (origKey !== undefined) process.env.ANTHROPIC_API_KEY = origKey;
+    }
+});
+
+await test("runInfrastructurePlannerTask with invalid key hits callLLM (auth error)", async () => {
+    try {
+        await runInfrastructurePlannerTask("Plan pipeline for 5 wells in Midland, Texas", {
+            apiKey: "sk-ant-invalid-key-for-test",
+        });
+        assert.fail("Should have thrown with auth error");
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        assert.ok(
+            msg.toLowerCase().includes("auth") ||
+                msg.toLowerCase().includes("unauthorized") ||
+                msg.toLowerCase().includes("invalid") ||
+                msg.toLowerCase().includes("api"),
+            `Expected auth error from callLLM, got: ${msg}`,
+        );
+    }
+});
+
+console.log("\n🔒 Error classification exports...");
+await test("RetryableToolError is importable from sdk", () => {
+    assert.ok(RetryableToolError, "RetryableToolError must be exported from @shaleyeah/sdk");
+});
+
+await test("PermanentToolError is importable from sdk", () => {
+    assert.ok(PermanentToolError, "PermanentToolError must be exported from @shaleyeah/sdk");
+});
+
+console.log("\n🙋 HITL approval_required contract (no live server needed)...");
+await test("approvalMode: 'always' returns approval_required before calling handler", async () => {
+    const strictRuntime = createInfrastructurePlannerRuntime({
+        ...infrastructurePlannerConfig,
+        hitl: { ...infrastructurePlannerConfig.hitl, approvalMode: "always" },
+    });
+    await strictRuntime.initialize();
+    const result = await strictRuntime.execute({
+        toolName: "infrastructure-planner.plan_pipeline",
+        args: { wellCount: 10, expectedProduction: 5000, location: "Reeves County, Texas" },
+    });
+    assert.strictEqual(result.status, "approval_required");
+    await strictRuntime.shutdown();
+});
+
+console.log("\n🌐 Integration tests (live infrastructure server required)...");
+if (!LIVE_SERVER) {
+    console.log("  ⚠️  [skipped] infrastructure server not reachable at localhost:3012");
+} else {
+    await test("plan_pipeline returns pipeline plan via live server", async () => {
+        const result = await callInfrastructureTool(
+            infrastructurePlannerConfig.mcpServers!["infrastructure"]!.url,
+            "plan_pipeline",
+            { wellCount: 10, expectedProduction: 5000, location: "Reeves County, Texas" },
+        );
+        assert.ok(result, "Must return a result");
+    });
+}
+
+console.log("\n══════════════════════════════════════════════");
+console.log(`Infrastructure Planner MCP Client Tests: ${passed} passed, ${failed} failed`);
+console.log("══════════════════════════════════════════════");
+
+if (failed > 0) process.exit(1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,13 +109,22 @@ importers:
 
   agents/infrastructure-planner:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@shaleyeah/sdk':
         specifier: workspace:*
         version: link:../../sdk
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.11
+        version: 2.4.16
       '@types/node':
         specifier: ^25.6.0
         version: 25.9.1
+      tsx:
+        specifier: ^4.21.0
+        version: 4.22.4
       typescript:
         specifier: ^6.0.2
         version: 6.0.3

--- a/servers/infrastructure/CHANGELOG.md
+++ b/servers/infrastructure/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Step A: Tier 1 server modularization** (#375) — Split monolithic `src/index.ts` (single `plan_infrastructure` tool) into four focused domain modules under `src/tools/`:
+  - `pipeline.ts` — gathering/transmission routing, `derivePipelinePlan()`, `synthesizePipelinePlanWithLLM()`
+  - `facilities.ts` — battery/separator/compressor/SWD sizing, `deriveFacilitySizing()`, `synthesizeFacilitySizingWithLLM()`
+  - `cost-estimation.ts` — CAPEX with contingency, `deriveInfrastructureCostEstimate()`, `synthesizeCostEstimateWithLLM()`
+  - `compliance.ts` — permits and approval timeline, `deriveComplianceAssessment()`, `synthesizeComplianceAssessmentWithLLM()`
+- **Four MCP tools** replace the single `plan_infrastructure`: `plan_pipeline`, `size_facilities`, `estimate_costs`, `assess_compliance`
+- `tests/tools.test.ts` — 28 tests covering domain math (gathering miles, facility ratios, CAPEX benchmarks, compliance risk)
+
 ## [0.1.0] — 2026-06-04
 
 ### Added

--- a/servers/infrastructure/src/index.ts
+++ b/servers/infrastructure/src/index.ts
@@ -1,184 +1,191 @@
 #!/usr/bin/env node
 
 /**
- * Infrastructure MCP Server - DRY Refactored
- * Structura Ingenious - Master Infrastructure Architect
+ * Infrastructure MCP Server
+ * Structura Ingenious — Master Infrastructure Architect
+ *
+ * Four focused tools replacing the original monolithic plan_infrastructure:
+ *   plan_pipeline     — gathering/transmission routing, capacity, takeaway risk
+ *   size_facilities   — batteries, separators, compressors, SWD wells
+ *   estimate_costs    — pipeline + facility + compression + SWD CAPEX
+ *   assess_compliance — permits, approval timeline, environmental risk
  */
 
-import fs from "node:fs/promises";
 import { callLLM, runMCPServer, ServerFactory, type ServerTemplate, ServerUtils } from "@shaleyeah/sdk";
 import { z } from "zod";
+import {
+    type ComplianceAssessment,
+    deriveComplianceAssessment,
+    synthesizeComplianceAssessmentWithLLM,
+} from "./tools/compliance.js";
+import {
+    type FacilitySizing,
+    deriveFacilitySizing,
+    synthesizeFacilitySizingWithLLM,
+} from "./tools/facilities.js";
+import {
+    type InfrastructureCostEstimate,
+    deriveInfrastructureCostEstimate,
+    synthesizeCostEstimateWithLLM,
+} from "./tools/cost-estimation.js";
+import { type PipelinePlan, derivePipelinePlan, synthesizePipelinePlanWithLLM } from "./tools/pipeline.js";
 
-// ---------------------------------------------------------------------------
-// Exported helpers (used by tests)
-// ---------------------------------------------------------------------------
+export type { PipelinePlan, FacilitySizing, InfrastructureCostEstimate, ComplianceAssessment };
+export {
+    derivePipelinePlan,
+    synthesizePipelinePlanWithLLM,
+    deriveFacilitySizing,
+    synthesizeFacilitySizingWithLLM,
+    deriveInfrastructureCostEstimate,
+    synthesizeCostEstimateWithLLM,
+    deriveComplianceAssessment,
+    synthesizeComplianceAssessmentWithLLM,
+};
 
+// Backward-compatibility shim — existing tests import this interface and helper.
 export interface InfrastructureInterpretation {
-	takeawayRisk: string;
-	keyConstraints: string[];
-	recommendation: string;
+    takeawayRisk: string;
+    keyConstraints: string[];
+    recommendation: string;
 }
 
-/**
- * Rule-based infrastructure interpretation — fallback when the API is unavailable.
- * Output varies with well count and production so tests can verify determinism.
- */
 export function deriveDefaultInfrastructureInterpretation(
-	wellCount: number,
-	expectedProduction: number,
-	location: string,
+    wellCount: number,
+    expectedProduction: number,
+    location: string,
 ): InfrastructureInterpretation {
-	const isLargeProject = wellCount > 20 || expectedProduction > 10000;
-	const isRemote = !["texas", "oklahoma", "kansas"].some((s) => location.toLowerCase().includes(s));
-
-	return {
-		takeawayRisk: isRemote ? "High" : isLargeProject ? "Medium" : "Low",
-		keyConstraints: [
-			`${wellCount} wells require ${Math.ceil(wellCount * 1.2)} miles of gathering line`,
-			isLargeProject ? "Large project — phased infrastructure buildout recommended" : "Single-phase buildout feasible",
-			isRemote
-				? "Remote location — midstream access may require new pipeline"
-				: "Existing midstream infrastructure accessible",
-		],
-		recommendation: `${isRemote ? "Secure midstream contract before committing capital." : "Standard gathering buildout."} ${isLargeProject ? "Phase infrastructure to match production ramp." : "Single phase appropriate for project scale."}`,
-	};
+    const plan = derivePipelinePlan(wellCount, expectedProduction, location);
+    return {
+        takeawayRisk: plan.takeawayRisk,
+        keyConstraints: [
+            `${wellCount} wells require ${plan.gatheringMiles} miles of gathering line`,
+            wellCount > 20 || expectedProduction > 10000
+                ? "Large project — phased infrastructure buildout recommended"
+                : "Single-phase buildout feasible",
+            plan.takeawayRisk === "High"
+                ? "Remote location — midstream access may require new pipeline"
+                : "Existing midstream infrastructure accessible",
+        ],
+        recommendation: plan.recommendation,
+    };
 }
 
-/**
- * Ask Claude (Structura Ingenious) to assess takeaway constraints and midstream risk.
- * Falls back to deriveDefaultInfrastructureInterpretation() if the API is unavailable.
- */
 export async function synthesizeInfrastructureAnalysisWithLLM(params: {
-	wellCount: number;
-	expectedProduction: number;
-	location: string;
-	totalCost: number;
+    wellCount: number;
+    expectedProduction: number;
+    location: string;
+    totalCost: number;
 }): Promise<InfrastructureInterpretation> {
-	const { wellCount, expectedProduction, location, totalCost } = params;
-
-	const prompt = `You are Structura Ingenious, a master infrastructure architect for oil & gas projects.
-
-Assess the infrastructure and takeaway constraints for this project. Return a JSON object.
-
-PROJECT:
-Well count: ${wellCount}
-Expected production: ${expectedProduction} bopd
-Location: ${location}
-Estimated infrastructure cost: $${(totalCost / 1_000_000).toFixed(2)}M
-
-Return ONLY valid JSON in this exact shape:
-{
-  "takeawayRisk": "High" | "Medium" | "Low",
-  "keyConstraints": ["<constraint 1>", "<constraint 2>", "<constraint 3>"],
-  "recommendation": "<one sentence infrastructure recommendation>"
-}`;
-
-	try {
-		const raw = await callLLM({ prompt, maxTokens: 350 });
-		const match = raw.match(/\{[\s\S]*\}/);
-		if (!match) throw new Error("No JSON in response");
-		const parsed = JSON.parse(match[0]) as Partial<InfrastructureInterpretation>;
-		const validRisks = ["High", "Medium", "Low"];
-		if (!validRisks.includes(parsed.takeawayRisk ?? "")) throw new Error("Invalid takeawayRisk");
-		return {
-			takeawayRisk: parsed.takeawayRisk as string,
-			keyConstraints: parsed.keyConstraints ?? [],
-			recommendation: parsed.recommendation ?? "",
-		};
-	} catch (_err) {
-		return deriveDefaultInfrastructureInterpretation(wellCount, expectedProduction, location);
-	}
+    const { wellCount, expectedProduction, location } = params;
+    try {
+        const plan = await synthesizePipelinePlanWithLLM({ wellCount, expectedProduction, location });
+        return {
+            takeawayRisk: plan.takeawayRisk,
+            keyConstraints: [plan.recommendation],
+            recommendation: plan.recommendation,
+        };
+    } catch {
+        return deriveDefaultInfrastructureInterpretation(wellCount, expectedProduction, location);
+    }
 }
 
 const infrastructureTemplate: ServerTemplate = {
-	name: "infrastructure",
-	description: "Infrastructure Planning MCP Server",
-	persona: {
-		name: "Structura Ingenious",
-		role: "Master Infrastructure Architect",
-		expertise: [
-			"Pipeline and facility design",
-			"Capacity planning and optimization",
-			"Infrastructure integration",
-			"Cost estimation and budgeting",
-			"Regulatory compliance planning",
-		],
-	},
-	directories: ["plans", "capacity", "costs", "compliance", "reports"],
-	tools: [
-		ServerFactory.createAnalysisTool(
-			"plan_infrastructure",
-			"Plan infrastructure for development project",
-			z.object({
-				projectScope: z.object({
-					expectedProduction: z.number(),
-					wellCount: z.number(),
-					location: z.string(),
-				}),
-				requirements: z.array(z.string()),
-				constraints: z
-					.object({
-						budget: z.number().optional(),
-						timeline: z.string().optional(),
-						environmental: z.array(z.string()).optional(),
-					})
-					.optional(),
-				outputPath: z.string().optional(),
-			}),
-			async (args) => {
-				const totalCost = Math.round(args.projectScope.wellCount * 430000);
-
-				// Ask Claude to assess takeaway constraints and midstream risk.
-				// Falls back to rule-based interpretation if API is unavailable.
-				const interpretation = await synthesizeInfrastructureAnalysisWithLLM({
-					wellCount: args.projectScope.wellCount,
-					expectedProduction: args.projectScope.expectedProduction,
-					location: args.projectScope.location,
-					totalCost,
-				});
-
-				const analysis = {
-					project: args.projectScope,
-					interpretation,
-					infrastructure: {
-						pipelines: {
-							gathering: `${Math.round(args.projectScope.wellCount * 1.2)} miles`,
-							transmission: "12 miles to existing network",
-							capacity: `${Math.round(args.projectScope.expectedProduction * 1.1)} bopd`,
-						},
-						facilities: {
-							batteries: Math.ceil(args.projectScope.wellCount / 8),
-							separators: Math.ceil(args.projectScope.wellCount / 4),
-							compressors: Math.ceil(args.projectScope.expectedProduction / 5000),
-						},
-						costs: {
-							pipelines: Math.round(args.projectScope.wellCount * 250000),
-							facilities: Math.round(args.projectScope.wellCount * 180000),
-							total: totalCost,
-						},
-					},
-					compliance: {
-						permits: ["Pipeline ROW", "Facility Construction", "Environmental"],
-						timeline: "6-8 months for approvals",
-						risks: args.constraints?.environmental || [],
-					},
-					confidence: ServerUtils.calculateConfidence(0.85, 0.9),
-				};
-
-				if (args.outputPath) {
-					await fs.writeFile(args.outputPath, JSON.stringify(analysis, null, 2));
-				}
-
-				return analysis;
-			},
-		),
-	],
+    name: "infrastructure",
+    description: "Infrastructure Planning MCP Server — pipeline, facilities, costs, and compliance",
+    persona: {
+        name: "Structura Ingenious",
+        role: "Master Infrastructure Architect",
+        expertise: [
+            "Pipeline and gathering system design",
+            "Surface facility sizing and layout",
+            "Infrastructure capital cost estimation",
+            "Permitting and regulatory compliance",
+            "Midstream takeaway capacity planning",
+        ],
+    },
+    directories: ["plans", "capacity", "costs", "compliance", "reports"],
+    tools: [
+        ServerFactory.createAnalysisTool(
+            "plan_pipeline",
+            "Plan gathering and transmission pipeline infrastructure — routing, capacity, and takeaway risk",
+            z.object({
+                wellCount: z.number().describe("Number of wells to connect"),
+                expectedProduction: z.number().describe("Expected total production in BOPD"),
+                location: z.string().describe("Project location (state, basin, or county)"),
+            }),
+            async (args) => {
+                const result = await synthesizePipelinePlanWithLLM({
+                    wellCount: args.wellCount,
+                    expectedProduction: args.expectedProduction,
+                    location: args.location,
+                });
+                return { ...result, confidence: ServerUtils.calculateConfidence(0.85, 0.9) };
+            },
+        ),
+        ServerFactory.createAnalysisTool(
+            "size_facilities",
+            "Size surface facilities — batteries, separators, compressors, and salt water disposal wells",
+            z.object({
+                wellCount: z.number().describe("Number of wells"),
+                expectedProduction: z.number().describe("Expected total production in BOPD"),
+                location: z.string().describe("Project location"),
+            }),
+            async (args) => {
+                const result = await synthesizeFacilitySizingWithLLM({
+                    wellCount: args.wellCount,
+                    expectedProduction: args.expectedProduction,
+                    location: args.location,
+                });
+                return { ...result, confidence: ServerUtils.calculateConfidence(0.85, 0.9) };
+            },
+        ),
+        ServerFactory.createAnalysisTool(
+            "estimate_costs",
+            "Estimate infrastructure capital costs (CAPEX) — pipelines, facilities, compression, and SWD",
+            z.object({
+                wellCount: z.number().describe("Number of wells"),
+                compressors: z.number().describe("Number of compressor units required"),
+                swdWells: z.number().describe("Number of salt water disposal wells required"),
+                location: z.string().describe("Project location"),
+            }),
+            async (args) => {
+                const result = await synthesizeCostEstimateWithLLM({
+                    wellCount: args.wellCount,
+                    compressors: args.compressors,
+                    swdWells: args.swdWells,
+                    location: args.location,
+                });
+                return { ...result, confidence: ServerUtils.calculateConfidence(0.85, 0.9) };
+            },
+        ),
+        ServerFactory.createAnalysisTool(
+            "assess_compliance",
+            "Assess permitting and regulatory compliance requirements — permits, timeline, and environmental risks",
+            z.object({
+                wellCount: z.number().describe("Number of wells"),
+                location: z.string().describe("Project location (state, basin, or county)"),
+                environmentalConstraints: z
+                    .array(z.string())
+                    .optional()
+                    .default([])
+                    .describe("Known environmental constraints or sensitivities"),
+            }),
+            async (args) => {
+                const result = await synthesizeComplianceAssessmentWithLLM({
+                    wellCount: args.wellCount,
+                    location: args.location,
+                    environmentalConstraints: args.environmentalConstraints ?? [],
+                });
+                return { ...result, confidence: ServerUtils.calculateConfidence(0.8, 0.85) };
+            },
+        ),
+    ],
 };
 
 export const InfrastructureServer = ServerFactory.createServer(infrastructureTemplate);
 export default InfrastructureServer;
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-	const server = new InfrastructureServer();
-	runMCPServer(server);
+    const server = new InfrastructureServer();
+    runMCPServer(server);
 }

--- a/servers/infrastructure/src/tools/compliance.ts
+++ b/servers/infrastructure/src/tools/compliance.ts
@@ -1,0 +1,77 @@
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface ComplianceAssessment {
+    requiredPermits: string[];
+    approvalTimelineMonths: number;
+    environmentalRisks: string[];
+    criticalPath: string;
+    complianceRisk: "High" | "Medium" | "Low";
+}
+
+/**
+ * Permit requirements for O&G infrastructure vary by state and project scale.
+ * Baseline: Pipeline ROW + Facility Construction + Environmental are always required.
+ * Remote/large projects trigger additional federal or state-level reviews.
+ * Approval timeline: 6–8 months for standard projects; up to 12 months for remote/federal land.
+ */
+export function deriveComplianceAssessment(
+    wellCount: number,
+    location: string,
+    environmentalConstraints: string[],
+): ComplianceAssessment {
+    const isRemote = !["texas", "oklahoma", "kansas"].some((s) => location.toLowerCase().includes(s));
+    const isLarge = wellCount > 20;
+
+    const requiredPermits = ["Pipeline Right-of-Way", "Facility Construction Permit", "Air Quality Permit (Title V)"];
+    if (isRemote) requiredPermits.push("Federal Surface Use Agreement", "NEPA Environmental Assessment");
+    if (isLarge) requiredPermits.push("Stormwater Pollution Prevention Plan (SWPPP)");
+
+    const approvalTimelineMonths = isRemote ? 12 : isLarge ? 9 : 6;
+    const complianceRisk: "High" | "Medium" | "Low" = isRemote ? "High" : isLarge ? "Medium" : "Low";
+
+    const environmentalRisks = environmentalConstraints.length > 0 ? environmentalConstraints : ["Standard erosion/runoff controls required"];
+
+    const criticalPath = isRemote
+        ? "Federal EA (NEPA) is the critical path — begin immediately; 6–9 months minimum"
+        : "Air quality permit is the critical path — submit 90 days before construction";
+
+    return { requiredPermits, approvalTimelineMonths, environmentalRisks, criticalPath, complianceRisk };
+}
+
+export async function synthesizeComplianceAssessmentWithLLM(params: {
+    wellCount: number;
+    location: string;
+    environmentalConstraints: string[];
+}): Promise<ComplianceAssessment> {
+    const { wellCount, location, environmentalConstraints } = params;
+
+    const prompt = `You are Structura Ingenious, a master O&G infrastructure architect.
+
+Assess the permitting and regulatory compliance requirements for this infrastructure project.
+
+PROJECT:
+Well count: ${wellCount}
+Location: ${location}
+Environmental constraints noted: ${environmentalConstraints.length > 0 ? environmentalConstraints.join(", ") : "none identified"}
+
+Return ONLY valid JSON matching this exact shape:
+{
+  "requiredPermits": ["<permit 1>", "<permit 2>", "..."],
+  "approvalTimelineMonths": <number — total calendar months for all permits>,
+  "environmentalRisks": ["<risk 1>", "..."],
+  "criticalPath": "<one sentence — what drives the schedule>",
+  "complianceRisk": "High" | "Medium" | "Low"
+}`;
+
+    try {
+        const raw = await callLLM({ prompt, maxTokens: 350 });
+        const match = raw.match(/\{[\s\S]*\}/);
+        if (!match) throw new Error("No JSON in response");
+        const parsed = JSON.parse(match[0]) as Partial<ComplianceAssessment>;
+        const validRisks = ["High", "Medium", "Low"];
+        if (!validRisks.includes(parsed.complianceRisk ?? "")) throw new Error("Invalid complianceRisk");
+        return parsed as ComplianceAssessment;
+    } catch {
+        return deriveComplianceAssessment(wellCount, location, environmentalConstraints);
+    }
+}

--- a/servers/infrastructure/src/tools/cost-estimation.ts
+++ b/servers/infrastructure/src/tools/cost-estimation.ts
@@ -1,0 +1,79 @@
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface InfrastructureCostEstimate {
+    pipelineCost: number;
+    facilitiesCost: number;
+    compressorCost: number;
+    swdCost: number;
+    totalCost: number;
+    costPerWell: number;
+    contingencyPct: number;
+}
+
+/**
+ * Cost benchmarks derived from Permian/DJ Basin midstream projects (2024–2025 USD):
+ *   - Gathering pipeline: $250,000/well (2-4" line, pad tie-ins, right-of-way)
+ *   - Facilities: $180,000/well (battery, separator, metering, controls)
+ *   - Compression: $400,000/unit (electric or gas-driven reciprocating compressor)
+ *   - SWD well: $1,200,000 each (drill, complete, surface equipment)
+ *   - Contingency: 15% for remote locations, 10% for established areas
+ */
+export function deriveInfrastructureCostEstimate(
+    wellCount: number,
+    compressors: number,
+    swdWells: number,
+    location: string,
+): InfrastructureCostEstimate {
+    const isRemote = !["texas", "oklahoma", "kansas"].some((s) => location.toLowerCase().includes(s));
+    const pipelineCost = wellCount * 250_000;
+    const facilitiesCost = wellCount * 180_000;
+    const compressorCost = compressors * 400_000;
+    const swdCost = swdWells * 1_200_000;
+    const subtotal = pipelineCost + facilitiesCost + compressorCost + swdCost;
+    const contingencyPct = isRemote ? 15 : 10;
+    const totalCost = Math.round(subtotal * (1 + contingencyPct / 100));
+    const costPerWell = Math.round(totalCost / wellCount);
+
+    return { pipelineCost, facilitiesCost, compressorCost, swdCost, totalCost, costPerWell, contingencyPct };
+}
+
+export async function synthesizeCostEstimateWithLLM(params: {
+    wellCount: number;
+    compressors: number;
+    swdWells: number;
+    location: string;
+}): Promise<InfrastructureCostEstimate> {
+    const { wellCount, compressors, swdWells, location } = params;
+    const fallback = deriveInfrastructureCostEstimate(wellCount, compressors, swdWells, location);
+
+    const prompt = `You are Structura Ingenious, a master O&G infrastructure architect.
+
+Estimate infrastructure capital costs (CAPEX) for this project.
+
+PROJECT:
+Well count: ${wellCount}
+Compressor units required: ${compressors}
+SWD (salt water disposal) wells required: ${swdWells}
+Location: ${location}
+Rough baseline: $${(fallback.totalCost / 1_000_000).toFixed(1)}M total
+
+Return ONLY valid JSON matching this exact shape:
+{
+  "pipelineCost": <number — USD for gathering pipelines>,
+  "facilitiesCost": <number — USD for surface facilities>,
+  "compressorCost": <number — USD for compression>,
+  "swdCost": <number — USD for salt water disposal>,
+  "totalCost": <number — total USD including contingency>,
+  "costPerWell": <number — USD per well>,
+  "contingencyPct": <number — contingency percentage applied>
+}`;
+
+    try {
+        const raw = await callLLM({ prompt, maxTokens: 300 });
+        const match = raw.match(/\{[\s\S]*\}/);
+        if (!match) throw new Error("No JSON in response");
+        return JSON.parse(match[0]) as InfrastructureCostEstimate;
+    } catch {
+        return fallback;
+    }
+}

--- a/servers/infrastructure/src/tools/facilities.ts
+++ b/servers/infrastructure/src/tools/facilities.ts
@@ -1,0 +1,73 @@
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface FacilitySizing {
+    batteries: number;
+    separators: number;
+    compressors: number;
+    saltWaterDisposalWells: number;
+    treatmentCapacityBwpd: number;
+    notes: string[];
+}
+
+/**
+ * Standard O&G surface facility sizing rules:
+ *   - 1 battery per 8 wells (manifolds + storage tanks per pad cluster)
+ *   - 1 separator per 4 wells (three-phase: oil/gas/water)
+ *   - 1 compressor per 5,000 BOPD equivalent production
+ *   - SWD wells: 1 per 10 wells minimum; saltwater volumes ≈ 3× oil production
+ */
+export function deriveFacilitySizing(wellCount: number, expectedProduction: number): FacilitySizing {
+    const batteries = Math.ceil(wellCount / 8);
+    const separators = Math.ceil(wellCount / 4);
+    const compressors = Math.ceil(expectedProduction / 5000);
+    const saltWaterDisposalWells = Math.max(1, Math.ceil(wellCount / 10));
+    const treatmentCapacityBwpd = Math.round(expectedProduction * 3);
+
+    const notes: string[] = [
+        `${batteries} battery station${batteries > 1 ? "s" : ""} — oil storage + metering for ${wellCount} wells`,
+        `${separators} three-phase separator${separators > 1 ? "s" : ""} — oil/gas/water separation`,
+        `SWD capacity sized for ${treatmentCapacityBwpd.toLocaleString()} BWPD (barrels of water per day)`,
+    ];
+
+    if (compressors > 2) {
+        notes.push(`${compressors} compressors required — consider centralized compression facility`);
+    }
+
+    return { batteries, separators, compressors, saltWaterDisposalWells, treatmentCapacityBwpd, notes };
+}
+
+export async function synthesizeFacilitySizingWithLLM(params: {
+    wellCount: number;
+    expectedProduction: number;
+    location: string;
+}): Promise<FacilitySizing> {
+    const { wellCount, expectedProduction, location } = params;
+
+    const prompt = `You are Structura Ingenious, a master O&G infrastructure architect.
+
+Size the surface facilities for this project.
+
+PROJECT:
+Well count: ${wellCount}
+Expected production: ${expectedProduction} BOPD
+Location: ${location}
+
+Return ONLY valid JSON matching this exact shape:
+{
+  "batteries": <number — oil battery stations>,
+  "separators": <number — three-phase separators>,
+  "compressors": <number — compression units>,
+  "saltWaterDisposalWells": <number — SWD wells>,
+  "treatmentCapacityBwpd": <number — water treatment capacity in BWPD>,
+  "notes": ["<note 1>", "<note 2>", "<note 3>"]
+}`;
+
+    try {
+        const raw = await callLLM({ prompt, maxTokens: 350 });
+        const match = raw.match(/\{[\s\S]*\}/);
+        if (!match) throw new Error("No JSON in response");
+        return JSON.parse(match[0]) as FacilitySizing;
+    } catch {
+        return deriveFacilitySizing(wellCount, expectedProduction);
+    }
+}

--- a/servers/infrastructure/src/tools/pipeline.ts
+++ b/servers/infrastructure/src/tools/pipeline.ts
@@ -1,0 +1,76 @@
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface PipelinePlan {
+    gatheringMiles: number;
+    transmissionMiles: number;
+    capacityBopd: number;
+    pressureRequirementPsi: number;
+    takeawayRisk: "High" | "Medium" | "Low";
+    recommendation: string;
+}
+
+/**
+ * Gathering miles scale linearly with well count; transmission is fixed at 12 miles
+ * to the nearest existing midstream network (representative Permian/DJ assumption).
+ * Capacity is sized 10% above expected production to handle flush production peaks.
+ * Pressure: remote locations require higher compression due to longer haul distances.
+ */
+export function derivePipelinePlan(wellCount: number, expectedProduction: number, location: string): PipelinePlan {
+    const isRemote = !["texas", "oklahoma", "kansas"].some((s) => location.toLowerCase().includes(s));
+    const gatheringMiles = Math.ceil(wellCount * 1.2);
+    const transmissionMiles = 12;
+    const capacityBopd = Math.round(expectedProduction * 1.1);
+    const pressureRequirementPsi = isRemote ? 1200 : 800;
+    const takeawayRisk: "High" | "Medium" | "Low" =
+        isRemote ? "High" : wellCount > 20 || expectedProduction > 10000 ? "Medium" : "Low";
+
+    return {
+        gatheringMiles,
+        transmissionMiles,
+        capacityBopd,
+        pressureRequirementPsi,
+        takeawayRisk,
+        recommendation: isRemote
+            ? "Secure midstream transport agreement before committing capital — no existing tie-in available."
+            : `Connect to existing midstream network via ${transmissionMiles}-mile transmission line.`,
+    };
+}
+
+export async function synthesizePipelinePlanWithLLM(params: {
+    wellCount: number;
+    expectedProduction: number;
+    location: string;
+}): Promise<PipelinePlan> {
+    const { wellCount, expectedProduction, location } = params;
+
+    const prompt = `You are Structura Ingenious, a master O&G infrastructure architect.
+
+Plan the pipeline gathering and transmission infrastructure for this project.
+
+PROJECT:
+Well count: ${wellCount}
+Expected production: ${expectedProduction} BOPD (barrels of oil per day)
+Location: ${location}
+
+Return ONLY valid JSON matching this exact shape:
+{
+  "gatheringMiles": <number — miles of gathering line to connect all wells>,
+  "transmissionMiles": <number — miles to existing midstream network>,
+  "capacityBopd": <number — design capacity in BOPD>,
+  "pressureRequirementPsi": <number — design inlet pressure in PSI>,
+  "takeawayRisk": "High" | "Medium" | "Low",
+  "recommendation": "<one sentence pipeline strategy>"
+}`;
+
+    try {
+        const raw = await callLLM({ prompt, maxTokens: 300 });
+        const match = raw.match(/\{[\s\S]*\}/);
+        if (!match) throw new Error("No JSON in response");
+        const parsed = JSON.parse(match[0]) as Partial<PipelinePlan>;
+        const validRisks = ["High", "Medium", "Low"];
+        if (!validRisks.includes(parsed.takeawayRisk ?? "")) throw new Error("Invalid takeawayRisk");
+        return parsed as PipelinePlan;
+    } catch {
+        return derivePipelinePlan(wellCount, expectedProduction, location);
+    }
+}

--- a/servers/infrastructure/tests/tools.test.ts
+++ b/servers/infrastructure/tests/tools.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Infrastructure Server Domain Logic Tests — Issue #375
+ *
+ * Tests the deterministic math in each tool module. No LLM calls, no server process.
+ */
+
+import assert from "node:assert";
+import { deriveComplianceAssessment } from "../src/tools/compliance.js";
+import { deriveFacilitySizing } from "../src/tools/facilities.js";
+import { deriveInfrastructureCostEstimate } from "../src/tools/cost-estimation.js";
+import { derivePipelinePlan } from "../src/tools/pipeline.js";
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void): void {
+    try {
+        fn();
+        console.log(`  ✅ ${name}`);
+        passed++;
+    } catch (err) {
+        console.error(`  ❌ ${name}: ${err instanceof Error ? err.message : err}`);
+        failed++;
+    }
+}
+
+// ── Pipeline ─────────────────────────────────────────────────────────────────
+
+console.log("\n📐 Pipeline planning...");
+
+test("gathering miles = ceil(wellCount × 1.2)", () => {
+    const plan = derivePipelinePlan(10, 5000, "Reeves County, Texas");
+    assert.strictEqual(plan.gatheringMiles, 12); // ceil(10 × 1.2)
+});
+
+test("transmission miles is fixed at 12", () => {
+    const plan = derivePipelinePlan(5, 2000, "Reeves County, Texas");
+    assert.strictEqual(plan.transmissionMiles, 12);
+});
+
+test("capacity = round(expectedProduction × 1.1)", () => {
+    const plan = derivePipelinePlan(10, 5000, "Reeves County, Texas");
+    assert.strictEqual(plan.capacityBopd, 5500); // round(5000 × 1.1)
+});
+
+test("Texas location → Low takeaway risk for small project", () => {
+    const plan = derivePipelinePlan(5, 2000, "Reeves County, Texas");
+    assert.strictEqual(plan.takeawayRisk, "Low");
+});
+
+test("remote location → High takeaway risk", () => {
+    const plan = derivePipelinePlan(5, 2000, "Uinta Basin, Utah");
+    assert.strictEqual(plan.takeawayRisk, "High");
+});
+
+test("large project in Texas → Medium takeaway risk", () => {
+    const plan = derivePipelinePlan(25, 15000, "Midland Basin, Texas");
+    assert.strictEqual(plan.takeawayRisk, "Medium");
+});
+
+test("remote location → higher pressure requirement", () => {
+    const remote = derivePipelinePlan(5, 2000, "Uinta Basin, Utah");
+    const local = derivePipelinePlan(5, 2000, "Reeves County, Texas");
+    assert.ok(remote.pressureRequirementPsi > local.pressureRequirementPsi);
+});
+
+// ── Facilities ───────────────────────────────────────────────────────────────
+
+console.log("\n🏭 Facility sizing...");
+
+test("batteries = ceil(wellCount / 8)", () => {
+    const sizing = deriveFacilitySizing(16, 8000);
+    assert.strictEqual(sizing.batteries, 2); // ceil(16 / 8)
+});
+
+test("separators = ceil(wellCount / 4)", () => {
+    const sizing = deriveFacilitySizing(16, 8000);
+    assert.strictEqual(sizing.separators, 4); // ceil(16 / 4)
+});
+
+test("compressors = ceil(production / 5000)", () => {
+    const sizing = deriveFacilitySizing(20, 10001);
+    assert.strictEqual(sizing.compressors, 3); // ceil(10001 / 5000)
+});
+
+test("SWD wells = max(1, ceil(wellCount / 10))", () => {
+    const single = deriveFacilitySizing(5, 2000);
+    assert.strictEqual(single.saltWaterDisposalWells, 1);
+
+    const multi = deriveFacilitySizing(25, 10000);
+    assert.strictEqual(multi.saltWaterDisposalWells, 3); // ceil(25 / 10)
+});
+
+test("water treatment capacity = round(production × 3)", () => {
+    const sizing = deriveFacilitySizing(10, 5000);
+    assert.strictEqual(sizing.treatmentCapacityBwpd, 15000);
+});
+
+test("notes array is non-empty", () => {
+    const sizing = deriveFacilitySizing(8, 4000);
+    assert.ok(sizing.notes.length >= 3);
+});
+
+// ── Cost Estimation ───────────────────────────────────────────────────────────
+
+console.log("\n💰 Cost estimation...");
+
+test("pipeline cost = wellCount × $250,000", () => {
+    const est = deriveInfrastructureCostEstimate(10, 2, 1, "Reeves County, Texas");
+    assert.strictEqual(est.pipelineCost, 2_500_000);
+});
+
+test("facilities cost = wellCount × $180,000", () => {
+    const est = deriveInfrastructureCostEstimate(10, 2, 1, "Reeves County, Texas");
+    assert.strictEqual(est.facilitiesCost, 1_800_000);
+});
+
+test("compressor cost = count × $400,000", () => {
+    const est = deriveInfrastructureCostEstimate(10, 3, 1, "Reeves County, Texas");
+    assert.strictEqual(est.compressorCost, 1_200_000);
+});
+
+test("SWD cost = count × $1,200,000", () => {
+    const est = deriveInfrastructureCostEstimate(10, 2, 2, "Reeves County, Texas");
+    assert.strictEqual(est.swdCost, 2_400_000);
+});
+
+test("Texas location → 10% contingency", () => {
+    const est = deriveInfrastructureCostEstimate(10, 2, 1, "Reeves County, Texas");
+    assert.strictEqual(est.contingencyPct, 10);
+});
+
+test("remote location → 15% contingency", () => {
+    const est = deriveInfrastructureCostEstimate(10, 2, 1, "Uinta Basin, Utah");
+    assert.strictEqual(est.contingencyPct, 15);
+});
+
+test("totalCost includes contingency", () => {
+    const est = deriveInfrastructureCostEstimate(10, 2, 1, "Reeves County, Texas");
+    const subtotal = est.pipelineCost + est.facilitiesCost + est.compressorCost + est.swdCost;
+    assert.strictEqual(est.totalCost, Math.round(subtotal * 1.1));
+});
+
+test("costPerWell = round(totalCost / wellCount)", () => {
+    const est = deriveInfrastructureCostEstimate(10, 2, 1, "Reeves County, Texas");
+    assert.strictEqual(est.costPerWell, Math.round(est.totalCost / 10));
+});
+
+// ── Compliance ───────────────────────────────────────────────────────────────
+
+console.log("\n📋 Compliance assessment...");
+
+test("always includes core permits (ROW, construction, air quality)", () => {
+    const result = deriveComplianceAssessment(10, "Reeves County, Texas", []);
+    assert.ok(result.requiredPermits.some((p) => p.includes("Right-of-Way")));
+    assert.ok(result.requiredPermits.some((p) => p.includes("Construction")));
+    assert.ok(result.requiredPermits.some((p) => p.includes("Air Quality")));
+});
+
+test("remote location → federal permits added + High risk", () => {
+    const result = deriveComplianceAssessment(10, "Uinta Basin, Utah", []);
+    assert.strictEqual(result.complianceRisk, "High");
+    assert.ok(result.requiredPermits.some((p) => p.includes("Federal")));
+    assert.ok(result.requiredPermits.some((p) => p.includes("NEPA")));
+});
+
+test("large Texas project → Medium risk + SWPPP", () => {
+    const result = deriveComplianceAssessment(25, "Midland Basin, Texas", []);
+    assert.strictEqual(result.complianceRisk, "Medium");
+    assert.ok(result.requiredPermits.some((p) => p.includes("SWPPP")));
+});
+
+test("small Texas project → Low risk + 6-month timeline", () => {
+    const result = deriveComplianceAssessment(5, "Reeves County, Texas", []);
+    assert.strictEqual(result.complianceRisk, "Low");
+    assert.strictEqual(result.approvalTimelineMonths, 6);
+});
+
+test("remote location → 12-month approval timeline", () => {
+    const result = deriveComplianceAssessment(10, "Uinta Basin, Utah", []);
+    assert.strictEqual(result.approvalTimelineMonths, 12);
+});
+
+test("passed environmental constraints appear in result", () => {
+    const constraints = ["endangered species habitat within 2 miles"];
+    const result = deriveComplianceAssessment(10, "Reeves County, Texas", constraints);
+    assert.ok(result.environmentalRisks.some((r) => r.includes("endangered")));
+});
+
+test("criticalPath is a non-empty string", () => {
+    const result = deriveComplianceAssessment(10, "Reeves County, Texas", []);
+    assert.ok(result.criticalPath.length > 0);
+});
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+console.log("\n══════════════════════════════════════════════");
+console.log(`Infrastructure Server Domain Tests: ${passed} passed, ${failed} failed`);
+console.log("══════════════════════════════════════════════");
+
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Step A** — `servers/infrastructure`: split monolithic `plan_infrastructure` into 4 focused MCP tools backed by domain modules with deterministic fallbacks + LLM synthesis (`plan_pipeline`, `size_facilities`, `estimate_costs`, `assess_compliance`); 28 domain logic tests
- **Step B** — `agents/infrastructure-planner`: full Tier 2 agent with manifest (4 tools, port 3012), `runInfrastructurePlannerTask()` Layer 2 execution loop, MCP HTTP client; 12 + 31 contract tests

## Test plan

- [ ] `npx tsx servers/infrastructure/tests/tools.test.ts` — 28 pass
- [ ] `npx tsx agents/infrastructure-planner/tests/mcp-client.test.ts` — 12 pass
- [ ] `npx tsx agents/infrastructure-planner/tests/agent.test.ts` — 31 pass
- [ ] `pnpm turbo build --filter @shaleyeah/server-infrastructure --filter @shaleyeah/infrastructure-planner` — clean
- [ ] Integration: `PORT=3012 cd servers/infrastructure && pnpm start` → agent client round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)