### PR TITLE
feat(drilling): Tier 1 server modularization + Tier 2 drilling-engineer agent (#374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **drilling / drilling-engineer pair — Steps A + B** (#374) — Full Tier 1 server modularization and Tier 2 agent implementation for well drilling engineering.
+  - `servers/drilling/src/tools/` — 3 focused modules (program, costs, risks) with LLM synthesis + deterministic fallbacks; `tests/tools.test.ts` (30 tests)
+  - `agents/drilling-engineer/src/agent/` — manifest (3 tools, port 3003), runtime config, `runDrillingEngineerTask()` Layer 2 loop, drilling MCP HTTP client; `tests/mcp-client.test.ts` (13) + `tests/agent.test.ts` (34)
+
 - **title / title-analyst pair — Steps A + B** (#372) — Full Tier 1 server modularization and Tier 2 agent implementation for oil & gas title analysis.
   - `servers/title/src/tools/` — 4 focused modules (ownership, lease-analysis, burden-check, chain-of-title) with LLM synthesis + deterministic fallbacks; `tests/tools.test.ts` (22 tests)
   - `agents/title-analyst/src/agent/` — manifest (4 tools, port 3010), runtime config, `runTitleAnalystTask()` Layer 2 loop, title MCP HTTP client; `tests/mcp-client.test.ts` (13) + `tests/agent.test.ts` (31)

--- a/agents/drilling-engineer/CHANGELOG.md
+++ b/agents/drilling-engineer/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog — @shaleyeah/drilling-engineer
+
+## [Unreleased]
+
+## [0.1.0] — 2026-06-10
+
+### Added
+- Initial Tier 2 agent implementation — `drillingEngineerManifest`, `drillingEngineerConfig`, `runDrillingEngineerTask` (#374)
+- `src/agent/drilling-client.ts` — MCP HTTP client with 30s timeout, RetryableToolError/PermanentToolError classification
+- `src/agent/index.ts` — 3-tool manifest (`design_drilling_program`, `estimate_well_costs`, `assess_drilling_risks`), LocalAgentRuntime wiring, Layer 2 LLM execution loop
+- `tests/mcp-client.test.ts` — 13 tests: HTTP client, Layer 2 runTask, SDK error exports, HITL gate
+- `tests/agent.test.ts` — 34 contract tests: manifest validation, discovery, model routing, HITL, evals, scope enforcement, blocking eval halt
+- Pairs with `servers/drilling` (default port 3003, `DRILLING_MCP_URL` env var)

--- a/agents/drilling-engineer/package.json
+++ b/agents/drilling-engineer/package.json
@@ -4,16 +4,22 @@
   "description": "Drilling Engineer — Tier 2 intelligence layer for drilling engineering",
   "private": true,
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/agent/index.js",
   "scripts": {
     "build": "tsc",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "npx tsx tests/mcp-client.test.ts && npx tsx tests/agent.test.ts",
+    "lint": "biome check src/ tests/",
+    "start": "node dist/agent/index.js"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@shaleyeah/sdk": "workspace:*"
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
     "@types/node": "^25.6.0",
+    "tsx": "^4.19.2",
     "typescript": "^6.0.2"
   }
 }

--- a/agents/drilling-engineer/src/agent/drilling-client.ts
+++ b/agents/drilling-engineer/src/agent/drilling-client.ts
@@ -1,0 +1,62 @@
+/**
+ * Drilling MCP client — thin wrapper that connects to the drilling Tier 1 server over HTTP,
+ * calls a single tool, and closes the connection.
+ * One-shot per call: simpler than managing a persistent connection for a standalone agent
+ * that may not run co-located with the drilling server at all times.
+ *
+ * Implements Arcade patterns:
+ *   #28 Timeout Boundary — configurable timeoutMs, default 30s
+ *   #39 Recovery Guide   — error messages include tool name and cause
+ *   #40 Error Classification — RetryableToolError vs PermanentToolError
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { PermanentToolError, RetryableToolError } from "@shaleyeah/sdk";
+
+export async function callDrillingTool(
+	url: string,
+	toolName: string,
+	args: Record<string, unknown>,
+	options: { timeoutMs?: number } = {},
+): Promise<unknown> {
+	const timeoutMs = options.timeoutMs ?? 30_000;
+
+	// Race the actual call against a timeout. If the timeout fires first, the MCP
+	// client continues in the background until its own connection handling cleans up.
+	const timeoutPromise = new Promise<never>((_, reject) =>
+		setTimeout(
+			() => reject(new RetryableToolError(`Tool call to ${toolName} timed out after ${timeoutMs}ms`)),
+			timeoutMs,
+		),
+	);
+
+	const callPromise = (async () => {
+		const transport = new StreamableHTTPClientTransport(new URL(url));
+		const client = new Client({ name: "drilling-engineer", version: "0.1.0" });
+		await client.connect(transport);
+		try {
+			const result = await client.callTool({ name: toolName, arguments: args });
+			return result.content;
+		} finally {
+			await client.close().catch(() => {});
+		}
+	})();
+
+	try {
+		return await Promise.race([callPromise, timeoutPromise]);
+	} catch (err) {
+		// Preserve already-classified errors from the timeout promise.
+		if (err instanceof RetryableToolError || err instanceof PermanentToolError) throw err;
+
+		const msg = err instanceof Error ? err.message : String(err);
+
+		// Network-level failures are transient — the server may be starting or briefly overloaded.
+		if (/ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENETUNREACH|fetch failed/i.test(msg)) {
+			throw new RetryableToolError(`Network error calling ${toolName}: ${msg}`, err instanceof Error ? err : undefined);
+		}
+
+		// Everything else (bad tool name, invalid args, auth, file not found) is permanent.
+		throw new PermanentToolError(`Tool call to ${toolName} failed: ${msg}`, err instanceof Error ? err : undefined);
+	}
+}

--- a/agents/drilling-engineer/src/agent/index.ts
+++ b/agents/drilling-engineer/src/agent/index.ts
@@ -1,0 +1,379 @@
+import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
+import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import { callDrillingTool } from "./drilling-client.js";
+
+export { callDrillingTool };
+
+// ── Manifest ──────────────────────────────────────────────────────────────────
+
+export const drillingEngineerManifest: AgentManifest = {
+	id: "drilling-engineer",
+	role: "drilling-analyst",
+	version: "0.1.0",
+	description:
+		"Perforator Maximus — drilling engineer agent that designs programs, estimates costs, and assesses drilling risks.",
+	persona: {
+		name: "Perforator Maximus",
+		role: "Master Drilling Strategist",
+		expertise: [
+			"Drilling program design",
+			"Well trajectory optimization",
+			"Drilling risk assessment",
+			"Cost estimation and budgeting",
+			"Technical troubleshooting",
+		],
+	},
+	capabilities: [
+		"drilling-program-design",
+		"well-cost-estimation",
+		"drilling-risk-assessment",
+		"model-routing",
+		"evals",
+	],
+	tools: [
+		{
+			name: "drilling-engineer.design_drilling_program",
+			description: "Design comprehensive drilling program with casing schedule and mud program.",
+			type: "query",
+			capabilities: ["drilling-program-design"],
+			inputSchema: {
+				type: "object",
+				properties: {
+					wellParameters: {
+						type: "object",
+						properties: {
+							targetDepth: { type: "number" },
+							wellType: { type: "string", enum: ["vertical", "horizontal", "directional"] },
+							formation: { type: "string" },
+						},
+						required: ["targetDepth", "wellType", "formation"],
+					},
+					constraints: {
+						type: "object",
+						properties: {
+							budget: { type: "number" },
+							timeline: { type: "string" },
+						},
+					},
+				},
+				required: ["wellParameters"],
+			},
+			readOnly: true,
+			destructive: false,
+			requiresHumanApproval: false,
+			requiredScopes: ["read:drilling"],
+			modelRequirement: "standard-analysis",
+			evalProfile: "drilling-engineer-program",
+			mcpServer: "drilling",
+		},
+		{
+			name: "drilling-engineer.estimate_well_costs",
+			description: "Estimate drilling, completion, and facilities cost breakdown for a well.",
+			type: "query",
+			capabilities: ["well-cost-estimation"],
+			inputSchema: {
+				type: "object",
+				properties: {
+					wellParameters: {
+						type: "object",
+						properties: {
+							targetDepth: { type: "number" },
+							wellType: { type: "string", enum: ["vertical", "horizontal", "directional"] },
+							formation: { type: "string" },
+						},
+						required: ["targetDepth", "wellType", "formation"],
+					},
+					location: { type: "string" },
+				},
+				required: ["wellParameters"],
+			},
+			readOnly: true,
+			destructive: false,
+			requiresHumanApproval: false,
+			requiredScopes: ["read:drilling"],
+			modelRequirement: "standard-analysis",
+			evalProfile: "drilling-engineer-costs",
+			mcpServer: "drilling",
+		},
+		{
+			name: "drilling-engineer.assess_drilling_risks",
+			description: "Assess geological, operational, and environmental drilling risks with mitigations.",
+			type: "query",
+			capabilities: ["drilling-risk-assessment"],
+			inputSchema: {
+				type: "object",
+				properties: {
+					wellParameters: {
+						type: "object",
+						properties: {
+							targetDepth: { type: "number" },
+							wellType: { type: "string", enum: ["vertical", "horizontal", "directional"] },
+							formation: { type: "string" },
+						},
+						required: ["targetDepth", "wellType", "formation"],
+					},
+					environmentalConstraints: { type: "array", items: { type: "string" } },
+				},
+				required: ["wellParameters"],
+			},
+			readOnly: true,
+			destructive: false,
+			requiresHumanApproval: false,
+			requiredScopes: ["read:drilling"],
+			modelRequirement: "standard-analysis",
+			evalProfile: "drilling-engineer-risks",
+			mcpServer: "drilling",
+		},
+	],
+	requiredScopes: ["read:drilling"],
+	providerRequirements: [
+		{ type: "llm", required: true, description: "Anthropic Claude — standard analysis" },
+	],
+	compatibility: {
+		agentRuntime: "^0.1.0",
+		remoteEndpoint: "^0.1.0",
+		mcp: "2025-03",
+	},
+	health: {
+		readinessChecks: ["manifest", "runtime-config", "tool-handlers", "model-routing"],
+	},
+	memory: {
+		namespace: "drilling-engineer",
+		reviewRequired: true,
+		sharedMemoryOptIn: false,
+	},
+	evals: {
+		defaultProfile: "drilling-engineer-default",
+		requiredChecks: ["schema", "redactSecrets"],
+	},
+	autonomy: {
+		defaultLevel: "assistive",
+		allowedLevels: ["assistive", "reviewed"],
+	},
+};
+
+// ── Runtime config ────────────────────────────────────────────────────────────
+
+export const drillingEngineerConfig: AgentRuntimeConfig = {
+	autonomy: "assistive",
+	modelRouting: {
+		"small-fast": { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+		"standard-analysis": { provider: "anthropic", model: "claude-sonnet-4-6" },
+		"deep-reasoning": { provider: "anthropic", model: "claude-opus-4-8" },
+		"local-private": { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+		deterministic: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+	},
+	hitl: {
+		approvalMode: "when-sensitive",
+		requireForDestructive: true,
+		requireForMemoryPromotion: true,
+	},
+	evals: {
+		enabled: true,
+		profile: "drilling-engineer-default",
+		checks: {
+			schema: "blocking",
+			domainCompleteness: "advisory",
+			confidenceMinimum: 0.7,
+			requireSources: false,
+			redactSecrets: "blocking",
+			memoryPromotion: "reviewed-only",
+		},
+	},
+	memory: {
+		enabled: true,
+		namespace: "drilling-engineer",
+		vectorStore: { enabled: false },
+		retentionDays: 30,
+		promotion: { requireHumanReview: true, allowSharedMemory: false },
+	},
+	mcpServers: {
+		drilling: {
+			url: process.env.DRILLING_MCP_URL ?? "http://localhost:3003",
+			transport: "http",
+			authType: "none",
+		},
+	},
+	dataConnectors: {},
+};
+
+// ── URL helper ────────────────────────────────────────────────────────────────
+
+function drillingUrl(config: AgentRuntimeConfig): string {
+	return config.mcpServers?.["drilling"]?.url ?? "http://localhost:3003";
+}
+
+// ── Handler map ───────────────────────────────────────────────────────────────
+
+const handlers: Record<string, StandaloneToolHandler> = {
+	"drilling-engineer.design_drilling_program": ({ args, config }) =>
+		callDrillingTool(drillingUrl(config), "design_drilling_program", args as Record<string, unknown>),
+	"drilling-engineer.estimate_well_costs": ({ args, config }) =>
+		callDrillingTool(drillingUrl(config), "estimate_well_costs", args as Record<string, unknown>),
+	"drilling-engineer.assess_drilling_risks": ({ args, config }) =>
+		callDrillingTool(drillingUrl(config), "assess_drilling_risks", args as Record<string, unknown>),
+};
+
+// ── Runtime + Endpoint factories ──────────────────────────────────────────────
+
+export function createDrillingEngineerRuntime(config: AgentRuntimeConfig = drillingEngineerConfig): LocalAgentRuntime {
+	return new LocalAgentRuntime({ manifest: drillingEngineerManifest, config, handlers });
+}
+
+export function createDrillingEngineerEndpoint(config: AgentRuntimeConfig = drillingEngineerConfig): LocalAgentEndpoint {
+	return new LocalAgentEndpoint(createDrillingEngineerRuntime(config));
+}
+
+// ── Task execution loop (Layer 2) ─────────────────────────────────────────────
+/**
+ * Run a multi-step drilling-engineer task driven by the LLM.
+ *
+ * All tool calls route through LocalAgentRuntime.execute() — HITL gate, scope
+ * checks, and audit logging fire on every step (Arcade #46: Permission Gate).
+ *
+ * options.runtime            — caller-managed runtime (e.g. in tests)
+ * options.onApprovalRequired — HITL callback; throws if omitted and approval is required
+ *
+ * Deferred (#395): Context Injection — read/write memory namespace around the loop.
+ * Deferred (#396): Async Job — polling for long-running tools.
+ */
+export async function runDrillingEngineerTask(
+	goal: string,
+	options: {
+		config?: AgentRuntimeConfig;
+		apiKey?: string;
+		runtime?: LocalAgentRuntime;
+		onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+	} = {},
+): Promise<string> {
+	const config = options.config ?? drillingEngineerConfig;
+
+	let runtime = options.runtime;
+	let ownedRuntime = false;
+	if (!runtime) {
+		runtime = createDrillingEngineerRuntime(config);
+		await runtime.initialize();
+		ownedRuntime = true;
+	}
+
+	try {
+		return await executeLoop(goal, runtime, options);
+	} finally {
+		if (ownedRuntime) await runtime.shutdown();
+	}
+}
+
+function buildTranscript(history: Array<{ role: "user" | "assistant" | "tool"; content: string }>): string {
+	return history
+		.map((t) => {
+			if (t.role === "user") return `User: ${t.content}`;
+			if (t.role === "assistant") return `Assistant: ${t.content}`;
+			return `Tool result: ${t.content}`;
+		})
+		.join("\n\n");
+}
+
+function parseJson(
+	text: string,
+): { action?: string; tool?: string; args?: Record<string, unknown>; answer?: string } | null {
+	try {
+		const cleaned = text
+			.replace(/^```(?:json)?\s*/m, "")
+			.replace(/\s*```\s*$/m, "")
+			.trim();
+		return JSON.parse(cleaned);
+	} catch {
+		return null;
+	}
+}
+
+async function executeLoop(
+	goal: string,
+	runtime: LocalAgentRuntime,
+	options: {
+		apiKey?: string;
+		onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+	},
+): Promise<string> {
+	// TODO (#395): Context Injection — read from memory.namespace before building system prompt.
+
+	const toolDefs = drillingEngineerManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+
+	const system = `You are ${drillingEngineerManifest.persona.name}, ${drillingEngineerManifest.persona.role}.
+
+Available tools:
+${toolDefs}
+
+Respond ONLY with valid JSON — no prose, no markdown. Two formats allowed:
+1. Call a tool:  {"action":"tool","tool":"<full tool name>","args":{...}}
+2. Final answer: {"action":"done","answer":"<synthesized answer>"}
+
+Always use the full tool name (e.g. "drilling-engineer.design_drilling_program").
+If you cannot complete the task with the available tools, respond with {"action":"done","answer":"<explanation>"}.`;
+
+	type Turn = { role: "user" | "assistant" | "tool"; content: string };
+	const history: Turn[] = [{ role: "user", content: goal }];
+	const MAX_STEPS = 8;
+
+	for (let step = 0; step < MAX_STEPS; step++) {
+		const response = await callLLM({
+			system,
+			prompt: `${buildTranscript(history)}\n\nAssistant:`,
+			apiKey: options.apiKey,
+		});
+
+		history.push({ role: "assistant", content: response });
+
+		const parsed = parseJson(response);
+		if (!parsed || parsed.action === "done" || !parsed.tool) {
+			return parsed?.answer ?? response;
+		}
+
+		// TODO (#396): Async Job — detect asyncJob tools and poll instead of blocking.
+
+		// Permission Gate: all tool calls go through runtime.execute() — never call
+		// the MCP client directly from the loop.
+		const execResult = await runtime.execute({
+			toolName: parsed.tool,
+			args: parsed.args ?? {},
+			runId: `task:step:${step}`,
+		});
+
+		if (execResult.status === "completed") {
+			history.push({ role: "tool", content: JSON.stringify(execResult.data) });
+		} else if (execResult.status === "approval_required") {
+			if (!options.onApprovalRequired) {
+				throw new Error(
+					`Tool ${parsed.tool} requires human approval. ` +
+						"Provide an onApprovalRequired callback to runDrillingEngineerTask, or set autonomy to 'autonomous'.",
+				);
+			}
+			const approval = await options.onApprovalRequired(execResult.challenge);
+			const approved = await runtime.execute({
+				toolName: parsed.tool,
+				args: parsed.args ?? {},
+				approval,
+				runId: `task:step:${step}:approved`,
+			});
+			if (approved.status === "completed") {
+				history.push({ role: "tool", content: JSON.stringify(approved.data) });
+			} else {
+				const err = approved.status === "failed" ? approved.error : "approval re-execution failed";
+				history.push({ role: "tool", content: `Error after approval for ${parsed.tool}: ${err}` });
+			}
+		} else {
+			const hint = execResult.retryable ? " (retryable — server may be temporarily unavailable)" : " (permanent)";
+			history.push({ role: "tool", content: `Error calling ${parsed.tool}: ${execResult.error}${hint}` });
+		}
+	}
+
+	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+
+	const finalResponse = await callLLM({
+		system,
+		prompt: `${buildTranscript(history)}\n\nUser: Maximum steps reached. Synthesize findings now.\n\nAssistant:`,
+		apiKey: options.apiKey,
+	});
+
+	return parseJson(finalResponse)?.answer ?? finalResponse;
+}

--- a/agents/drilling-engineer/src/index.ts
+++ b/agents/drilling-engineer/src/index.ts
@@ -1,20 +1,2 @@
-/**
- * Drilling Engineer Agent — stub, migration tracked in issue #374
- *
- * Implementation guide: .claude/rules/agent-template.md
- * Reference implementation: agents/geologist/src/agent/index.ts
- *
- * When implemented:
- *   src/agent/index.ts              — manifest + config + handlers + runDrillingEngineerTask
- *   src/agent/drilling-client.ts    — callDrillingTool (copy geowiz-client.ts, rename)
- *   tests/mcp-client.test.ts        — copy geologist mcp-client.test.ts
- *   tests/agent.test.ts             — copy geologist agent.test.ts
- *
- * Target server: drilling (servers/drilling, default port 3003)
- * Env var: DRILLING_MCP_URL
- */
-
 export const AGENT_ID = "drilling-engineer";
-
-// Uncomment and switch to this export once src/agent/index.ts is implemented:
-// export * from "./agent/index.js";
+export * from "./agent/index.js";

--- a/agents/drilling-engineer/tests/agent.test.ts
+++ b/agents/drilling-engineer/tests/agent.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Drilling Engineer Agent Contract Tests — Issue #374
+ *
+ * Proves the drilling tools are accessible through the AgentRuntime contract
+ * and that the drilling-engineer manifest satisfies all Arcade acceptance criteria.
+ */
+
+import { AgentManifestSchema, AgentRuntimeConfigSchema, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	createDrillingEngineerEndpoint,
+	createDrillingEngineerRuntime,
+	drillingEngineerConfig,
+	drillingEngineerManifest,
+} from "../src/agent/index.js";
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, message: string): void {
+	if (condition) {
+		console.log(`  ✅ ${message}`);
+		passed++;
+	} else {
+		console.error(`  ❌ ${message}`);
+		failed++;
+	}
+}
+
+async function drillingServerReachable(): Promise<boolean> {
+	try {
+		const url = drillingEngineerConfig.mcpServers?.drilling?.url ?? "http://localhost:3003";
+		const ctrl = new AbortController();
+		const timer = setTimeout(() => ctrl.abort(), 500);
+		await fetch(url, { method: "HEAD", signal: ctrl.signal });
+		clearTimeout(timer);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+console.log("🧪 Starting Drilling Engineer Agent Contract Tests (#374)\n");
+
+console.log("📋 Testing manifest and config validation...");
+{
+	const manifest = AgentManifestSchema.safeParse(drillingEngineerManifest);
+	assert(manifest.success, "Drilling engineer manifest validates");
+	if (!manifest.success) console.error("  ", manifest.error.format());
+
+	const config = AgentRuntimeConfigSchema.safeParse(drillingEngineerConfig);
+	assert(config.success, "Drilling engineer runtime config validates");
+
+	assert(drillingEngineerManifest.tools.length === 3, "Drilling engineer exposes 3 drilling tools");
+	assert(
+		drillingEngineerManifest.tools.every((t) => t.name.startsWith("drilling-engineer.")),
+		"All tools follow drilling-engineer. naming convention",
+	);
+	assert(
+		drillingEngineerManifest.tools.every((t) => !t.modelRequirement.includes("claude")),
+		"Model requirements are capability labels, not provider names",
+	);
+	const allToolScopes = new Set(drillingEngineerManifest.tools.flatMap((t) => t.requiredScopes));
+	assert(
+		[...allToolScopes].every((s) => drillingEngineerManifest.requiredScopes.includes(s)),
+		"Manifest requiredScopes is a superset of all tool requiredScopes",
+	);
+	const llmReq = drillingEngineerManifest.providerRequirements.find((p) => p.type === "llm");
+	assert(llmReq?.required === true, "LLM provider requirement is marked required");
+}
+
+console.log("\n🔎 Testing progressive discovery...");
+{
+	const runtime = createDrillingEngineerRuntime();
+	await runtime.initialize();
+
+	const summary = runtime.discover("summary");
+	assert("capabilities" in summary, "Summary discovery returns capabilities");
+	assert(!("tools" in summary), "Summary discovery does not include tool list");
+
+	const tools = runtime.discover("tools");
+	assert(Array.isArray(tools) && tools.length === 3, "Tool discovery returns 3 tools");
+	assert(!("inputSchema" in tools[0]), "Tool list omits input schemas");
+
+	const schema = runtime.discover("schema", "drilling-engineer.design_drilling_program");
+	assert(schema?.inputSchema !== undefined, "Schema discovery returns design_drilling_program input schema");
+	assert(
+		(schema?.inputSchema as Record<string, unknown>)?.required !== undefined,
+		"design_drilling_program schema declares required fields",
+	);
+
+	const missing = runtime.discover("schema", "drilling-engineer.nonexistent");
+	assert(missing === null, "Schema discovery returns null for unknown tool");
+
+	await runtime.shutdown();
+}
+
+console.log("\n🧭 Testing organization-owned model routing...");
+{
+	const live = await drillingServerReachable();
+	if (!live) {
+		console.log("  ⚠️  [skipped] drilling server not reachable — execute() tests require live server");
+		console.log("     Start with: cd servers/drilling && PORT=3003 pnpm start");
+	} else {
+		const runtime = createDrillingEngineerRuntime({
+			...drillingEngineerConfig,
+			modelRouting: {
+				...drillingEngineerConfig.modelRouting,
+				"standard-analysis": {
+					provider: "acme-drilling-llm",
+					model: "operator-selected-model",
+				},
+			},
+		});
+		await runtime.initialize();
+
+		const result = await runtime.execute({
+			toolName: "drilling-engineer.design_drilling_program",
+			args: {
+				wellParameters: { targetDepth: 10000, wellType: "horizontal", formation: "wolfcamp" },
+			},
+		});
+
+		assert(result.status === "completed", "Drilling program tool completes");
+
+		await runtime.shutdown();
+	}
+}
+
+console.log("\n📡 Testing model capability routing across requirement classes...");
+{
+	const runtime = createDrillingEngineerRuntime();
+	await runtime.initialize();
+
+	const modelRequirements = new Set(drillingEngineerManifest.tools.map((t) => t.modelRequirement));
+	assert(modelRequirements.has("standard-analysis"), "standard-analysis requirement present in tool suite");
+
+	for (const req of modelRequirements) {
+		const binding = drillingEngineerConfig.modelRouting[req];
+		assert(binding !== undefined, `Model route exists for requirement: ${req}`);
+	}
+
+	await runtime.shutdown();
+}
+
+console.log("\n🙋 Testing HITL policy wires through to config...");
+{
+	const live = await drillingServerReachable();
+
+	if (live) {
+		const runtime = createDrillingEngineerRuntime();
+		await runtime.initialize();
+
+		const result = await runtime.execute({
+			toolName: "drilling-engineer.design_drilling_program",
+			args: {
+				wellParameters: { targetDepth: 10000, wellType: "horizontal", formation: "wolfcamp" },
+			},
+		});
+		assert(result.status === "completed", "Drilling tools complete without approval challenge");
+
+		await runtime.shutdown();
+	} else {
+		console.log("  ⚠️  [skipped] execute() test requires live drilling server");
+	}
+
+	// approvalMode: "always" blocks BEFORE calling the handler — no server needed
+	const strictRuntime = createDrillingEngineerRuntime({
+		...drillingEngineerConfig,
+		hitl: { ...drillingEngineerConfig.hitl, approvalMode: "always" },
+	});
+	await strictRuntime.initialize();
+	const blocked = await strictRuntime.execute({
+		toolName: "drilling-engineer.design_drilling_program",
+		args: {
+			wellParameters: { targetDepth: 10000, wellType: "horizontal", formation: "wolfcamp" },
+		},
+	});
+	assert(blocked.status === "approval_required", "approvalMode: 'always' blocks all tools");
+	if (blocked.status === "approval_required") {
+		assert(blocked.challenge.type === "human_approval_required", "Challenge is structured");
+		assert(blocked.challenge.agentId === "drilling-engineer", "Challenge identifies drilling-engineer agent");
+	}
+
+	await strictRuntime.shutdown();
+}
+
+console.log("\n🧪 Testing evals policy is configured correctly...");
+{
+	const live = await drillingServerReachable();
+	if (!live) {
+		console.log("  ⚠️  [skipped] eval test requires live drilling server");
+	} else {
+		const runtime = createDrillingEngineerRuntime();
+		await runtime.initialize();
+
+		const result = await runtime.execute({
+			toolName: "drilling-engineer.design_drilling_program",
+			args: {
+				wellParameters: { targetDepth: 10000, wellType: "horizontal", formation: "wolfcamp" },
+			},
+		});
+
+		assert(result.status === "completed", "design_drilling_program completes for eval test");
+		if (result.status === "completed") {
+			assert(
+				result.evals.some((e) => e.check === "schema"),
+				"Schema eval ran",
+			);
+			assert(
+				result.evals.some((e) => e.check === "redactSecrets"),
+				"Secret-redaction eval ran",
+			);
+			assert(
+				result.evals.every((e) => e.status === "pass"),
+				"All evals pass on clean drilling output",
+			);
+		}
+
+		await runtime.shutdown();
+	}
+}
+
+console.log("\n🏥 Testing health endpoint and standalone boot...");
+{
+	const endpoint = createDrillingEngineerEndpoint();
+	const health = await endpoint.health();
+	assert(health.agentId === "drilling-engineer", "Health endpoint identifies drilling-engineer");
+	assert(health.status !== "not_ready", "Drilling engineer boots without external dependencies");
+
+	const manifest = await endpoint.manifest();
+	assert(manifest.id === "drilling-engineer", "Endpoint exposes drilling-engineer manifest");
+	assert(manifest.tools.length === 3, "Endpoint manifest has 3 tools");
+
+	const toolSchema = await endpoint.discoveryToolSchema("drilling-engineer.estimate_well_costs");
+	assert(toolSchema !== null, "Endpoint exposes tool schemas by name");
+}
+
+console.log("\n🔒 Testing scope enforcement...");
+{
+	const runtime = createDrillingEngineerRuntime();
+	await runtime.initialize();
+
+	const blocked = await runtime.execute({
+		toolName: "drilling-engineer.design_drilling_program",
+		args: {
+			wellParameters: { targetDepth: 10000, wellType: "horizontal", formation: "wolfcamp" },
+		},
+		grantedScopes: [],
+	});
+	assert(blocked.status === "failed", "Missing scope blocks tool execution");
+	if (blocked.status === "failed") {
+		assert(blocked.error.includes("Missing required scopes"), "Error message names missing scopes");
+	}
+
+	const allowed = await runtime.execute({
+		toolName: "drilling-engineer.design_drilling_program",
+		args: {
+			wellParameters: { targetDepth: 10000, wellType: "horizontal", formation: "wolfcamp" },
+		},
+		grantedScopes: ["read:drilling"],
+	});
+	assert(
+		allowed.status !== "failed" || !allowed.error.includes("Missing required scopes"),
+		"Correct scopes are accepted",
+	);
+
+	await runtime.shutdown();
+}
+
+console.log("\n🧱 Testing blocking eval halt...");
+{
+	const undefinedHandler = async () => undefined;
+	const allHandlers = Object.fromEntries(
+		drillingEngineerManifest.tools.map((t) => [t.name, undefinedHandler]),
+	);
+	const testRuntime = new LocalAgentRuntime({
+		manifest: drillingEngineerManifest,
+		config: drillingEngineerConfig,
+		handlers: allHandlers,
+	});
+	await testRuntime.initialize();
+	const result = await testRuntime.execute({
+		toolName: "drilling-engineer.design_drilling_program",
+		args: {
+			wellParameters: { targetDepth: 10000, wellType: "horizontal", formation: "wolfcamp" },
+		},
+	});
+	assert(result.status === "failed", "Blocking eval failure returns status: failed");
+	if (result.status === "failed") {
+		assert(result.error.includes("Blocking eval"), "Error message references blocking eval");
+		assert(result.retryable === false, "Blocking eval failures are not retryable");
+	}
+	await testRuntime.shutdown();
+}
+
+console.log("\n🔀 Testing model routing resolution...");
+{
+	const standardAnalysis = drillingEngineerConfig.modelRouting["standard-analysis"];
+	assert(standardAnalysis !== undefined, "standard-analysis binding is present");
+	assert(
+		standardAnalysis?.model !== "configured-by-operator",
+		"standard-analysis model is a real model ID, not a placeholder",
+	);
+	assert(standardAnalysis?.provider === "anthropic", "standard-analysis provider is anthropic");
+}
+
+console.log("\n🛑 Testing invalid manifest fails early...");
+{
+	try {
+		new LocalAgentRuntime({
+			manifest: { ...drillingEngineerManifest, id: "" } as typeof drillingEngineerManifest,
+			config: drillingEngineerConfig,
+			handlers: Object.fromEntries(
+				drillingEngineerManifest.tools.map((t) => [t.name, async () => ({})]),
+			),
+		});
+		assert(false, "Empty manifest id should fail validation");
+	} catch {
+		assert(true, "Invalid manifest id fails at construction");
+	}
+}
+
+console.log("\n══════════════════════════════════════════════");
+console.log(`Drilling Engineer Agent Contract Tests: ${passed} passed, ${failed} failed`);
+console.log("══════════════════════════════════════════════");
+
+if (failed > 0) {
+	process.exit(1);
+}

--- a/agents/drilling-engineer/tests/mcp-client.test.ts
+++ b/agents/drilling-engineer/tests/mcp-client.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Drilling Engineer MCP Client + runTask Tests — Issue #374
+ *
+ * Layer 1: verifies callDrillingTool delegates to the drilling server over HTTP.
+ * Layer 2: verifies runDrillingEngineerTask drives a multi-step LLM loop.
+ *
+ * Run: cd agents/drilling-engineer && npx tsx tests/mcp-client.test.ts
+ */
+
+import assert from "node:assert";
+import type { HumanApprovalChallenge } from "@shaleyeah/sdk";
+import { PermanentToolError, RetryableToolError } from "@shaleyeah/sdk";
+import {
+	callDrillingTool,
+	createDrillingEngineerRuntime,
+	drillingEngineerConfig,
+	drillingEngineerManifest,
+	runDrillingEngineerTask,
+} from "../src/agent/index.js";
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void | Promise<void>): Promise<void> {
+	return Promise.resolve()
+		.then(fn)
+		.then(() => {
+			console.log(`  ✓ ${name}`);
+			passed++;
+		})
+		.catch((err: unknown) => {
+			console.log(`  ✗ ${name}`);
+			console.log(`    ${err instanceof Error ? err.message : String(err)}`);
+			failed++;
+		});
+}
+
+async function drillingServerReachable(): Promise<boolean> {
+	try {
+		const url = drillingEngineerConfig.mcpServers?.drilling?.url ?? "http://localhost:3003";
+		const ctrl = new AbortController();
+		const timer = setTimeout(() => ctrl.abort(), 500);
+		await fetch(url, { method: "HEAD", signal: ctrl.signal });
+		clearTimeout(timer);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function runTests(): Promise<void> {
+	console.log("\n🧪 Drilling Engineer MCP Client + runTask Tests (#374)\n");
+
+	// ── Layer 1: HTTP client ──────────────────────────────────────────────────
+
+	await test("callDrillingTool is exported as a function", () => {
+		assert.strictEqual(typeof callDrillingTool, "function", "callDrillingTool must be exported");
+	});
+
+	await test('drillingEngineerConfig.mcpServers["drilling"].url is http://localhost:3003', () => {
+		const conn = drillingEngineerConfig.mcpServers?.drilling;
+		assert.ok(conn, 'mcpServers["drilling"] entry must be present');
+		assert.strictEqual(conn.url, "http://localhost:3003", "drilling URL must be localhost:3003");
+	});
+
+	await test('drillingEngineerConfig.mcpServers["drilling"].transport is http', () => {
+		const conn = drillingEngineerConfig.mcpServers?.drilling;
+		assert.ok(conn, 'mcpServers["drilling"] entry must be present');
+		assert.strictEqual(conn.transport, "http", "drilling transport must be http");
+	});
+
+	await test("all 3 drilling-engineer tools declare mcpServer: 'drilling'", () => {
+		const wrong = drillingEngineerManifest.tools.filter((t) => t.mcpServer !== "drilling");
+		assert.strictEqual(
+			wrong.length,
+			0,
+			`Tools without mcpServer='drilling': ${wrong.map((t) => t.name).join(", ")}`,
+		);
+	});
+
+	await test("drillingEngineerConfig.modelRouting['standard-analysis'] uses a real model ID (not placeholder)", () => {
+		const binding = drillingEngineerConfig.modelRouting["standard-analysis"];
+		assert.ok(binding, "standard-analysis binding must be present");
+		assert.notStrictEqual(binding?.model, "configured-by-operator", "model must not be a placeholder");
+		assert.strictEqual(binding?.provider, "anthropic", "provider must be anthropic");
+	});
+
+	await test("callDrillingTool rejects with a clear error when server is unreachable", async () => {
+		let threw = false;
+		try {
+			await callDrillingTool("http://localhost:19999", "design_drilling_program", {
+				wellParameters: { targetDepth: 10000, wellType: "horizontal", formation: "wolfcamp" },
+			});
+		} catch (err) {
+			threw = true;
+			const msg = err instanceof Error ? err.message : String(err);
+			assert.ok(msg.length > 0, "Error message must be non-empty");
+		}
+		assert.ok(threw, "callDrillingTool must throw when server is unreachable");
+	});
+
+	// ── Layer 2: runTask execution loop ───────────────────────────────────────
+
+	await test("runDrillingEngineerTask is exported as a function", () => {
+		assert.strictEqual(
+			typeof runDrillingEngineerTask,
+			"function",
+			"runDrillingEngineerTask must be exported",
+		);
+	});
+
+	await test("runDrillingEngineerTask throws when no ANTHROPIC_API_KEY is set", async () => {
+		const saved = process.env.ANTHROPIC_API_KEY;
+		process.env.ANTHROPIC_API_KEY = "";
+		let threw = false;
+		try {
+			await runDrillingEngineerTask("design a drilling program for a horizontal Wolfcamp well");
+		} catch (err) {
+			threw = true;
+			const msg = err instanceof Error ? err.message : String(err);
+			assert.ok(msg.includes("ANTHROPIC_API_KEY"), `Error must mention ANTHROPIC_API_KEY, got: ${msg}`);
+		} finally {
+			if (saved !== undefined) process.env.ANTHROPIC_API_KEY = saved;
+			else delete process.env.ANTHROPIC_API_KEY;
+		}
+		assert.ok(threw, "runDrillingEngineerTask must throw when no API key is set");
+	});
+
+	await test(
+		"runDrillingEngineerTask hits callLLM when API key is present (auth error confirms path)",
+		async () => {
+			let threw = false;
+			try {
+				await runDrillingEngineerTask("design a drilling program", {
+					apiKey: "sk-ant-invalid-key-for-test",
+				});
+			} catch (err) {
+				threw = true;
+				const msg = err instanceof Error ? err.message : String(err);
+				assert.ok(msg.length > 0, "Error from invalid key must have a message");
+			}
+			assert.ok(threw, "runDrillingEngineerTask with invalid key must throw (proves callLLM was hit)");
+		},
+	);
+
+	// ── SDK error exports ─────────────────────────────────────────────────────
+
+	await test("RetryableToolError is exported from @shaleyeah/sdk", () => {
+		assert.strictEqual(typeof RetryableToolError, "function");
+		const err = new RetryableToolError("test");
+		assert.strictEqual(err.retryable, true);
+	});
+
+	await test("PermanentToolError is exported from @shaleyeah/sdk", () => {
+		assert.strictEqual(typeof PermanentToolError, "function");
+		const err = new PermanentToolError("test");
+		assert.strictEqual(err.retryable, false);
+	});
+
+	// ── runDrillingEngineerTask runtime option ────────────────────────────────
+
+	await test("runDrillingEngineerTask accepts runtime option (signature check)", () => {
+		const params = runDrillingEngineerTask.length;
+		assert.ok(params >= 1, "runDrillingEngineerTask must accept at least a goal argument");
+	});
+
+	await test(
+		"runDrillingEngineerTask throws when approval_required and no onApprovalRequired callback",
+		async () => {
+			const runtime = createDrillingEngineerRuntime({
+				...drillingEngineerConfig,
+				hitl: { ...drillingEngineerConfig.hitl, approvalMode: "always" },
+			});
+			await runtime.initialize();
+			const result = await runtime.execute({
+				toolName: "drilling-engineer.design_drilling_program",
+				args: {
+					wellParameters: { targetDepth: 10000, wellType: "horizontal", formation: "wolfcamp" },
+				},
+			});
+			await runtime.shutdown();
+			assert.strictEqual(
+				result.status,
+				"approval_required",
+				"HITL gate must block with approvalMode='always'",
+			);
+			assert.ok("challenge" in result, "approval_required result must have a challenge");
+			const challenge = (result as { status: "approval_required"; challenge: HumanApprovalChallenge }).challenge;
+			assert.strictEqual(challenge.toolName, "drilling-engineer.design_drilling_program");
+		},
+	);
+
+	// ── Integration tests (require live drilling server + real API key) ────────
+
+	const live = await drillingServerReachable();
+	const HAS_API_KEY = !!process.env.ANTHROPIC_API_KEY;
+
+	if (!live) {
+		console.log(
+			"\n  ⚠️  [integration] drilling server not reachable at localhost:3003 — skipping live MCP tests.",
+		);
+		console.log("     Start with: cd servers/drilling && PORT=3003 pnpm start");
+	}
+	if (!HAS_API_KEY) {
+		console.log("  ⚠️  [integration] ANTHROPIC_API_KEY not set — skipping runTask live test.");
+	}
+
+	if (live) {
+		await test("[integration] callDrillingTool routes design_drilling_program through drilling MCP", async () => {
+			const result = await callDrillingTool(
+				drillingEngineerConfig.mcpServers!.drilling.url,
+				"design_drilling_program",
+				{
+					wellParameters: { targetDepth: 10000, wellType: "horizontal", formation: "wolfcamp" },
+				},
+			);
+			assert.ok(result !== undefined, "MCP tool call must return a value");
+		});
+	}
+
+	if (live && HAS_API_KEY) {
+		await test("[integration] runDrillingEngineerTask completes a multi-step drilling task", async () => {
+			const answer = await runDrillingEngineerTask(
+				"Design a drilling program for a horizontal Wolfcamp well at 10,000ft and estimate costs.",
+			);
+			assert.strictEqual(typeof answer, "string", "runDrillingEngineerTask must return a string");
+			assert.ok(answer.length > 0, "Answer must be non-empty");
+		});
+	}
+
+	console.log(
+		`\nDrilling Engineer MCP Client + runTask Tests: ${passed} passed, ${failed} failed`,
+	);
+	if (failed > 0) process.exit(1);
+}
+
+await runTests();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,13 +52,22 @@ importers:
 
   agents/drilling-engineer:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@shaleyeah/sdk':
         specifier: workspace:*
         version: link:../../sdk
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
       '@types/node':
         specifier: ^25.6.0
         version: 25.9.1
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.4
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
@@ -652,15 +661,32 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
   '@biomejs/biome@2.4.16':
     resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@biomejs/cli-darwin-arm64@2.4.16':
     resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
     os: [darwin]
 
   '@biomejs/cli-darwin-x64@2.4.16':
@@ -669,12 +695,26 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@biomejs/cli-linux-arm64-musl@2.4.16':
     resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-arm64@2.4.16':
     resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
@@ -683,12 +723,26 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@biomejs/cli-linux-x64-musl@2.4.16':
     resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64@2.4.16':
     resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
@@ -697,10 +751,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
   '@biomejs/cli-win32-arm64@2.4.16':
     resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
     os: [win32]
 
   '@biomejs/cli-win32-x64@2.4.16':
@@ -2069,6 +2135,17 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
+  '@biomejs/biome@1.9.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
+
   '@biomejs/biome@2.4.16':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.4.16
@@ -2080,25 +2157,49 @@ snapshots:
       '@biomejs/cli-win32-arm64': 2.4.16
       '@biomejs/cli-win32-x64': 2.4.16
 
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
+
   '@biomejs/cli-darwin-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.4':
     optional: true
 
   '@biomejs/cli-darwin-x64@2.4.16':
     optional: true
 
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
+
   '@biomejs/cli-linux-arm64-musl@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.4':
     optional: true
 
   '@biomejs/cli-linux-arm64@2.4.16':
     optional: true
 
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
+
   '@biomejs/cli-linux-x64-musl@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.4':
     optional: true
 
   '@biomejs/cli-linux-x64@2.4.16':
     optional: true
 
+  '@biomejs/cli-win32-arm64@1.9.4':
+    optional: true
+
   '@biomejs/cli-win32-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
   '@biomejs/cli-win32-x64@2.4.16':

--- a/servers/drilling/CHANGELOG.md
+++ b/servers/drilling/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-06-10
+
+### Added
+- Split monolithic `index.ts` into 3 focused domain modules: `src/tools/program.ts`, `src/tools/costs.ts`, `src/tools/risks.ts` (#374)
+- Added `estimate_well_costs` MCP tool — drilling/completion/facilities cost breakdown by well type and depth
+- Added `assess_drilling_risks` MCP tool — geological, operational, and environmental risk scoring with mitigations
+- Added `tests/tools.test.ts` with 30 unit tests covering domain logic (no API key required)
+- Backward-compat shims: `deriveDefaultDrillingInterpretation` and `synthesizeDrillingAnalysisWithLLM` preserved
+
 ## [0.1.0] — 2026-06-04
 
 ### Added

--- a/servers/drilling/src/index.ts
+++ b/servers/drilling/src/index.ts
@@ -1,15 +1,18 @@
 #!/usr/bin/env node
 /**
- * Drilling MCP Server - DRY Refactored
- * Perforator Maximus - Master Drilling Strategist
+ * Drilling MCP Server — Perforator Maximus, Master Drilling Strategist.
+ * Thin facade — all domain logic lives in src/tools/.
  */
 
-import fs from "node:fs/promises";
-import { callLLM, runMCPServer, ServerFactory, type ServerTemplate, ServerUtils } from "@shaleyeah/sdk";
+import { runMCPServer, ServerFactory, type ServerTemplate, ServerUtils } from "@shaleyeah/sdk";
 import { z } from "zod";
 
+import { deriveDrillingProgram, synthesizeDrillingProgramWithLLM } from "./tools/program.js";
+import { deriveWellCostBreakdown, synthesizeWellCostsWithLLM } from "./tools/costs.js";
+import { deriveDrillingRiskProfile, synthesizeDrillingRisksWithLLM } from "./tools/risks.js";
+
 // ---------------------------------------------------------------------------
-// Exported helpers (used by tests)
+// Backward-compat exports — existing tests import these from ../src/index.js
 // ---------------------------------------------------------------------------
 
 export interface DrillingInterpretation {
@@ -18,34 +21,14 @@ export interface DrillingInterpretation {
 	recommendation: string;
 }
 
-/**
- * Rule-based drilling interpretation — fallback when the API is unavailable.
- * Uses actual well parameters so output differs across inputs.
- */
 export function deriveDefaultDrillingInterpretation(
 	wellType: string,
 	targetDepth: number,
 	formation: string,
 ): DrillingInterpretation {
-	const isDeep = targetDepth > 12000;
-	const isHorizontal = wellType === "horizontal";
-	const riskLevel = isDeep && isHorizontal ? "High" : isDeep || isHorizontal ? "Medium" : "Low";
-
-	return {
-		programRisk: riskLevel,
-		keyConsiderations: [
-			`${wellType} well to ${targetDepth}ft in ${formation}`,
-			isDeep ? "Deep target — elevated pore pressure risk" : "Moderate depth — standard drilling hazards apply",
-			isHorizontal ? "Lateral section requires careful torque and drag management" : "Vertical profile — standard BHA",
-		],
-		recommendation: `Proceed with ${riskLevel.toLowerCase()}-risk mitigation plan. ${isHorizontal ? "Optimize lateral length vs. cost." : "Standard casing program appropriate."}`,
-	};
+	return deriveDrillingProgram(wellType as "vertical" | "horizontal" | "directional", targetDepth, formation);
 }
 
-/**
- * Ask Claude (Perforator Maximus) to interpret the drilling program and flag risks.
- * Falls back to deriveDefaultDrillingInterpretation() if the API is unavailable.
- */
 export async function synthesizeDrillingAnalysisWithLLM(params: {
 	wellType: string;
 	targetDepth: number;
@@ -53,42 +36,30 @@ export async function synthesizeDrillingAnalysisWithLLM(params: {
 	estimatedDays: number;
 	totalCost: number;
 }): Promise<DrillingInterpretation> {
-	const { wellType, targetDepth, formation, estimatedDays, totalCost } = params;
-
-	const prompt = `You are Perforator Maximus, a master drilling strategist.
-
-Interpret this drilling program and identify the key risks and recommendations. Return a JSON object.
-
-WELL PROGRAM:
-Well type: ${wellType}
-Target depth: ${targetDepth} ft
-Formation: ${formation}
-Estimated drill time: ${estimatedDays} days
-Total estimated cost: $${(totalCost / 1_000_000).toFixed(2)}M
-
-Return ONLY valid JSON in this exact shape:
-{
-  "programRisk": "High" | "Medium" | "Low",
-  "keyConsiderations": ["<risk or consideration 1>", "<risk or consideration 2>", "<risk or consideration 3>"],
-  "recommendation": "<one sentence drilling program recommendation>"
-}`;
-
-	try {
-		const raw = await callLLM({ prompt, maxTokens: 350 });
-		const match = raw.match(/\{[\s\S]*\}/);
-		if (!match) throw new Error("No JSON in response");
-		const parsed = JSON.parse(match[0]) as Partial<DrillingInterpretation>;
-		const validRisks = ["High", "Medium", "Low"];
-		if (!validRisks.includes(parsed.programRisk ?? "")) throw new Error("Invalid programRisk");
-		return {
-			programRisk: parsed.programRisk as string,
-			keyConsiderations: parsed.keyConsiderations ?? [],
-			recommendation: parsed.recommendation ?? "",
-		};
-	} catch (_err) {
-		return deriveDefaultDrillingInterpretation(wellType, targetDepth, formation);
-	}
+	return synthesizeDrillingProgramWithLLM({
+		wellType: params.wellType as "vertical" | "horizontal" | "directional",
+		targetDepth: params.targetDepth,
+		formation: params.formation,
+	});
 }
+
+// Re-export tool types for consumers
+export type { DrillingProgram } from "./tools/program.js";
+export type { WellCostBreakdown } from "./tools/costs.js";
+export type { DrillingRiskProfile } from "./tools/risks.js";
+export { deriveDrillingProgram, synthesizeDrillingProgramWithLLM } from "./tools/program.js";
+export { deriveWellCostBreakdown, synthesizeWellCostsWithLLM } from "./tools/costs.js";
+export { deriveDrillingRiskProfile, synthesizeDrillingRisksWithLLM } from "./tools/risks.js";
+
+// ---------------------------------------------------------------------------
+// Server template
+// ---------------------------------------------------------------------------
+
+const wellParamsSchema = z.object({
+	targetDepth: z.number(),
+	wellType: z.enum(["vertical", "horizontal", "directional"]),
+	formation: z.string(),
+});
 
 const drillingTemplate: ServerTemplate = {
 	name: "drilling",
@@ -108,85 +79,61 @@ const drillingTemplate: ServerTemplate = {
 	tools: [
 		ServerFactory.createAnalysisTool(
 			"design_drilling_program",
-			"Design comprehensive drilling program",
+			"Design comprehensive drilling program with casing schedule and mud program",
 			z.object({
-				wellParameters: z.object({
-					targetDepth: z.number(),
-					wellType: z.enum(["vertical", "horizontal", "directional"]),
-					formation: z.string(),
-				}),
-				location: z.object({
-					latitude: z.number(),
-					longitude: z.number(),
-					surface: z.string(),
-				}),
+				wellParameters: wellParamsSchema,
 				constraints: z
 					.object({
 						budget: z.number().optional(),
 						timeline: z.string().optional(),
-						environmental: z.array(z.string()).optional(),
 					})
 					.optional(),
-				outputPath: z.string().optional(),
 			}),
 			async (args) => {
-				const wellCost =
-					args.wellParameters.targetDepth *
-					(args.wellParameters.wellType === "horizontal"
-						? 180
-						: args.wellParameters.wellType === "directional"
-							? 140
-							: 120);
-
-				const estimatedDays = Math.ceil(
-					args.wellParameters.targetDepth / (args.wellParameters.wellType === "horizontal" ? 400 : 600),
-				);
-				const totalCost = Math.round(wellCost * 1.8);
-
-				// Ask Claude to interpret the program and flag formation-specific risks.
-				// Falls back to rule-based interpretation if API is unavailable.
-				const interpretation = await synthesizeDrillingAnalysisWithLLM({
+				const result = await synthesizeDrillingProgramWithLLM({
 					wellType: args.wellParameters.wellType,
 					targetDepth: args.wellParameters.targetDepth,
 					formation: args.wellParameters.formation,
-					estimatedDays,
-					totalCost,
+					budget: args.constraints?.budget,
+					timeline: args.constraints?.timeline,
 				});
+				return { ...result, confidence: ServerUtils.calculateConfidence(0.82, 0.88) };
+			},
+		),
 
-				const analysis = {
-					well: args.wellParameters,
-					location: args.location,
-					drilling: {
-						estimatedDays,
-						mudProgram: `${args.wellParameters.formation} optimized system`,
-						casingProgram: [
-							'20" conductor to 100ft',
-							'13 3/8" surface to 2,000ft',
-							args.wellParameters.wellType === "horizontal" ? '9 5/8" intermediate to TD' : '7" production to TD',
-						],
-						completion:
-							args.wellParameters.wellType === "horizontal" ? "Multi-stage fracturing" : "Conventional completion",
-					},
-					costs: {
-						drilling: Math.round(wellCost),
-						completion: Math.round(wellCost * 0.6),
-						facilities: Math.round(wellCost * 0.2),
-						total: totalCost,
-					},
-					risks: {
-						geological: args.wellParameters.formation.includes("shale") ? "Medium" : "Low",
-						operational: interpretation.programRisk,
-						environmental: args.constraints?.environmental?.length > 0 ? "Medium" : "Low",
-					},
-					interpretation,
-					confidence: ServerUtils.calculateConfidence(0.82, 0.88),
-				};
+		ServerFactory.createAnalysisTool(
+			"estimate_well_costs",
+			"Estimate drilling, completion, and facilities cost breakdown for a well",
+			z.object({
+				wellParameters: wellParamsSchema,
+				location: z.string().optional(),
+			}),
+			async (args) => {
+				const result = await synthesizeWellCostsWithLLM({
+					wellType: args.wellParameters.wellType,
+					targetDepth: args.wellParameters.targetDepth,
+					formation: args.wellParameters.formation,
+					location: args.location ?? "unspecified",
+				});
+				return { ...result, confidence: ServerUtils.calculateConfidence(0.80, 0.85) };
+			},
+		),
 
-				if (args.outputPath) {
-					await fs.writeFile(args.outputPath, JSON.stringify(analysis, null, 2));
-				}
-
-				return analysis;
+		ServerFactory.createAnalysisTool(
+			"assess_drilling_risks",
+			"Assess geological, operational, and environmental drilling risks with mitigations",
+			z.object({
+				wellParameters: wellParamsSchema,
+				environmentalConstraints: z.array(z.string()).optional(),
+			}),
+			async (args) => {
+				const result = await synthesizeDrillingRisksWithLLM({
+					wellType: args.wellParameters.wellType,
+					targetDepth: args.wellParameters.targetDepth,
+					formation: args.wellParameters.formation,
+					environmentalConstraints: args.environmentalConstraints ?? [],
+				});
+				return { ...result, confidence: ServerUtils.calculateConfidence(0.80, 0.88) };
 			},
 		),
 	],

--- a/servers/drilling/src/tools/costs.ts
+++ b/servers/drilling/src/tools/costs.ts
@@ -1,0 +1,93 @@
+/**
+ * Well cost estimation — drilling, completion, and facilities breakdown.
+ * Rates are industry-representative constants for onshore US unconventional wells.
+ */
+
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface WellCostBreakdown {
+	drillingCost: number;
+	completionCost: number;
+	facilitiesCost: number;
+	totalCost: number;
+	costPerFoot: number;
+	estimatedDays: number;
+}
+
+// Drilling cost per foot by well type (onshore US unconventional, 2024 basis)
+const COST_PER_FOOT: Record<"vertical" | "horizontal" | "directional", number> = {
+	horizontal: 180,
+	directional: 140,
+	vertical: 120,
+};
+
+export function deriveWellCostBreakdown(
+	wellType: "vertical" | "horizontal" | "directional",
+	targetDepth: number,
+): WellCostBreakdown {
+	const costPerFoot = COST_PER_FOOT[wellType];
+	const drillingCost = Math.round(targetDepth * costPerFoot);
+	const completionCost = Math.round(drillingCost * 0.6);
+	const facilitiesCost = Math.round(drillingCost * 0.2);
+	const totalCost = Math.round((drillingCost + completionCost + facilitiesCost) * 1.0);
+	const estimatedDays = Math.ceil(targetDepth / (wellType === "horizontal" ? 400 : 600));
+
+	return {
+		drillingCost,
+		completionCost,
+		facilitiesCost,
+		totalCost,
+		costPerFoot,
+		estimatedDays,
+	};
+}
+
+export async function synthesizeWellCostsWithLLM(params: {
+	wellType: "vertical" | "horizontal" | "directional";
+	targetDepth: number;
+	formation: string;
+	location: string;
+}): Promise<WellCostBreakdown> {
+	const { wellType, targetDepth, formation, location } = params;
+	const base = deriveWellCostBreakdown(wellType, targetDepth);
+
+	const prompt = `You are Perforator Maximus, a master drilling strategist.
+
+Estimate well costs for this project. Return a JSON object.
+
+WELL:
+Type: ${wellType}
+Depth: ${targetDepth} ft
+Formation: ${formation}
+Location: ${location}
+
+Baseline estimate: $${(base.totalCost / 1_000_000).toFixed(2)}M total
+
+Return ONLY valid JSON in this exact shape:
+{
+  "drillingCost": <number in dollars>,
+  "completionCost": <number in dollars>,
+  "facilitiesCost": <number in dollars>,
+  "totalCost": <number in dollars>,
+  "costPerFoot": <number>,
+  "estimatedDays": <number>
+}`;
+
+	try {
+		const raw = await callLLM({ prompt, maxTokens: 250 });
+		const match = raw.match(/\{[\s\S]*\}/);
+		if (!match) throw new Error("No JSON in response");
+		const parsed = JSON.parse(match[0]) as Partial<WellCostBreakdown>;
+		if (typeof parsed.totalCost !== "number") throw new Error("Missing totalCost");
+		return {
+			drillingCost: parsed.drillingCost ?? base.drillingCost,
+			completionCost: parsed.completionCost ?? base.completionCost,
+			facilitiesCost: parsed.facilitiesCost ?? base.facilitiesCost,
+			totalCost: parsed.totalCost,
+			costPerFoot: parsed.costPerFoot ?? base.costPerFoot,
+			estimatedDays: parsed.estimatedDays ?? base.estimatedDays,
+		};
+	} catch (_err) {
+		return base;
+	}
+}

--- a/servers/drilling/src/tools/program.ts
+++ b/servers/drilling/src/tools/program.ts
@@ -1,0 +1,104 @@
+/**
+ * Drilling program design — casing, mud, completion, and schedule.
+ * Deterministic fallback keeps tests independent of the Anthropic API.
+ */
+
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface DrillingProgram {
+	wellType: "vertical" | "horizontal" | "directional";
+	targetDepth: number;
+	formation: string;
+	estimatedDays: number;
+	casingProgram: string[];
+	mudProgram: string;
+	completionType: string;
+	programRisk: "High" | "Medium" | "Low";
+	keyConsiderations: string[];
+	recommendation: string;
+}
+
+export function deriveDrillingProgram(
+	wellType: "vertical" | "horizontal" | "directional",
+	targetDepth: number,
+	formation: string,
+): DrillingProgram {
+	const isDeep = targetDepth > 12000;
+	const isHorizontal = wellType === "horizontal";
+	const programRisk: "High" | "Medium" | "Low" =
+		isDeep && isHorizontal ? "High" : isDeep || isHorizontal ? "Medium" : "Low";
+
+	const estimatedDays = Math.ceil(targetDepth / (isHorizontal ? 400 : 600));
+
+	const casingProgram = [
+		'20" conductor to 100ft',
+		'13 3/8" surface to 2,000ft',
+		isHorizontal ? '9 5/8" intermediate to TD' : '7" production to TD',
+	];
+
+	return {
+		wellType,
+		targetDepth,
+		formation,
+		estimatedDays,
+		casingProgram,
+		mudProgram: `${formation} optimized system`,
+		completionType: isHorizontal ? "Multi-stage fracturing" : "Conventional completion",
+		programRisk,
+		keyConsiderations: [
+			`${wellType} well to ${targetDepth}ft in ${formation}`,
+			isDeep ? "Deep target — elevated pore pressure risk" : "Moderate depth — standard drilling hazards apply",
+			isHorizontal
+				? "Lateral section requires careful torque and drag management"
+				: "Vertical profile — standard BHA",
+		],
+		recommendation: `Proceed with ${programRisk.toLowerCase()}-risk mitigation plan. ${isHorizontal ? "Optimize lateral length vs. cost." : "Standard casing program appropriate."}`,
+	};
+}
+
+export async function synthesizeDrillingProgramWithLLM(params: {
+	wellType: "vertical" | "horizontal" | "directional";
+	targetDepth: number;
+	formation: string;
+	budget?: number;
+	timeline?: string;
+}): Promise<DrillingProgram> {
+	const { wellType, targetDepth, formation, budget, timeline } = params;
+
+	const prompt = `You are Perforator Maximus, a master drilling strategist.
+
+Design a drilling program and flag key risks. Return a JSON object.
+
+WELL PARAMETERS:
+Well type: ${wellType}
+Target depth: ${targetDepth} ft
+Formation: ${formation}
+${budget ? `Budget: $${(budget / 1_000_000).toFixed(2)}M` : ""}
+${timeline ? `Timeline: ${timeline}` : ""}
+
+Return ONLY valid JSON in this exact shape:
+{
+  "programRisk": "High" | "Medium" | "Low",
+  "keyConsiderations": ["<consideration 1>", "<consideration 2>", "<consideration 3>"],
+  "recommendation": "<one sentence drilling program recommendation>"
+}`;
+
+	try {
+		const raw = await callLLM({ prompt, maxTokens: 350 });
+		const match = raw.match(/\{[\s\S]*\}/);
+		if (!match) throw new Error("No JSON in response");
+		const parsed = JSON.parse(match[0]) as Partial<Pick<DrillingProgram, "programRisk" | "keyConsiderations" | "recommendation">>;
+		const validRisks: string[] = ["High", "Medium", "Low"];
+		if (!validRisks.includes(parsed.programRisk ?? "")) throw new Error("Invalid programRisk");
+
+		const base = deriveDrillingProgram(wellType, targetDepth, formation);
+		return {
+			...base,
+			programRisk: parsed.programRisk as "High" | "Medium" | "Low",
+			keyConsiderations: parsed.keyConsiderations ?? base.keyConsiderations,
+			recommendation: parsed.recommendation ?? base.recommendation,
+		};
+	} catch (_err) {
+		return deriveDrillingProgram(wellType, targetDepth, formation);
+	}
+}

--- a/servers/drilling/src/tools/risks.ts
+++ b/servers/drilling/src/tools/risks.ts
@@ -1,0 +1,89 @@
+/**
+ * Drilling risk assessment — geological, operational, and environmental risk scoring.
+ */
+
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface DrillingRiskProfile {
+	geologicalRisk: "High" | "Medium" | "Low";
+	operationalRisk: "High" | "Medium" | "Low";
+	environmentalRisk: "High" | "Medium" | "Low";
+	overallRisk: "High" | "Medium" | "Low";
+	mitigations: string[];
+}
+
+function highest(...risks: Array<"High" | "Medium" | "Low">): "High" | "Medium" | "Low" {
+	if (risks.includes("High")) return "High";
+	if (risks.includes("Medium")) return "Medium";
+	return "Low";
+}
+
+export function deriveDrillingRiskProfile(
+	wellType: "vertical" | "horizontal" | "directional",
+	targetDepth: number,
+	formation: string,
+	environmentalConstraints: string[],
+): DrillingRiskProfile {
+	const geologicalRisk: "High" | "Medium" | "Low" = formation.toLowerCase().includes("shale") ? "Medium" : "Low";
+	const isDeep = targetDepth > 12000;
+	const isHorizontal = wellType === "horizontal";
+	const operationalRisk: "High" | "Medium" | "Low" =
+		isDeep && isHorizontal ? "High" : isDeep || isHorizontal ? "Medium" : "Low";
+	const environmentalRisk: "High" | "Medium" | "Low" = environmentalConstraints.length > 0 ? "Medium" : "Low";
+	const overallRisk = highest(geologicalRisk, operationalRisk, environmentalRisk);
+
+	const mitigations: string[] = [];
+	if (operationalRisk !== "Low") mitigations.push("Real-time pore pressure monitoring required");
+	if (isHorizontal) mitigations.push("Torque and drag model before spud");
+	if (geologicalRisk !== "Low") mitigations.push("Formation evaluation LWD suite recommended");
+	if (environmentalConstraints.length > 0) mitigations.push("Environmental compliance officer on-site");
+	if (mitigations.length === 0) mitigations.push("Standard risk management plan appropriate");
+
+	return { geologicalRisk, operationalRisk, environmentalRisk, overallRisk, mitigations };
+}
+
+export async function synthesizeDrillingRisksWithLLM(params: {
+	wellType: "vertical" | "horizontal" | "directional";
+	targetDepth: number;
+	formation: string;
+	environmentalConstraints: string[];
+}): Promise<DrillingRiskProfile> {
+	const { wellType, targetDepth, formation, environmentalConstraints } = params;
+
+	const prompt = `You are Perforator Maximus, a master drilling strategist.
+
+Assess drilling risks for this well. Return a JSON object.
+
+WELL:
+Type: ${wellType}
+Depth: ${targetDepth} ft
+Formation: ${formation}
+Environmental constraints: ${environmentalConstraints.join(", ") || "none"}
+
+Return ONLY valid JSON in this exact shape:
+{
+  "geologicalRisk": "High" | "Medium" | "Low",
+  "operationalRisk": "High" | "Medium" | "Low",
+  "environmentalRisk": "High" | "Medium" | "Low",
+  "overallRisk": "High" | "Medium" | "Low",
+  "mitigations": ["<mitigation 1>", "<mitigation 2>"]
+}`;
+
+	try {
+		const raw = await callLLM({ prompt, maxTokens: 300 });
+		const match = raw.match(/\{[\s\S]*\}/);
+		if (!match) throw new Error("No JSON in response");
+		const parsed = JSON.parse(match[0]) as Partial<DrillingRiskProfile>;
+		const validRisks = ["High", "Medium", "Low"];
+		if (!validRisks.includes(parsed.overallRisk ?? "")) throw new Error("Invalid overallRisk");
+		return {
+			geologicalRisk: (validRisks.includes(parsed.geologicalRisk ?? "") ? parsed.geologicalRisk : "Low") as "High" | "Medium" | "Low",
+			operationalRisk: (validRisks.includes(parsed.operationalRisk ?? "") ? parsed.operationalRisk : "Low") as "High" | "Medium" | "Low",
+			environmentalRisk: (validRisks.includes(parsed.environmentalRisk ?? "") ? parsed.environmentalRisk : "Low") as "High" | "Medium" | "Low",
+			overallRisk: parsed.overallRisk as "High" | "Medium" | "Low",
+			mitigations: parsed.mitigations ?? [],
+		};
+	} catch (_err) {
+		return deriveDrillingRiskProfile(wellType, targetDepth, formation, environmentalConstraints);
+	}
+}

--- a/servers/drilling/tests/tools.test.ts
+++ b/servers/drilling/tests/tools.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Drilling Server — domain logic unit tests.
+ * Tests real math in deriveDrillingProgram, deriveWellCostBreakdown, deriveDrillingRiskProfile.
+ * No API key required.
+ */
+
+import assert from "node:assert";
+import { deriveDrillingProgram } from "../src/tools/program.js";
+import { deriveWellCostBreakdown } from "../src/tools/costs.js";
+import { deriveDrillingRiskProfile } from "../src/tools/risks.js";
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void): void {
+	try {
+		fn();
+		console.log(`  ✅ ${name}`);
+		passed++;
+	} catch (err) {
+		console.error(`  ❌ ${name}: ${err instanceof Error ? err.message : String(err)}`);
+		failed++;
+	}
+}
+
+// ── deriveDrillingProgram ─────────────────────────────────────────────────────
+
+console.log("\n=== DrillingProgram ===\n");
+
+test("shallow vertical → Low risk", () => {
+	const p = deriveDrillingProgram("vertical", 5000, "sandstone");
+	assert.strictEqual(p.programRisk, "Low");
+});
+
+test("deep vertical → Medium risk (deep but not horizontal)", () => {
+	const p = deriveDrillingProgram("vertical", 14000, "granite");
+	assert.strictEqual(p.programRisk, "Medium");
+});
+
+test("shallow horizontal → Medium risk (horizontal but not deep)", () => {
+	const p = deriveDrillingProgram("horizontal", 8000, "shale");
+	assert.strictEqual(p.programRisk, "Medium");
+});
+
+test("deep horizontal → High risk", () => {
+	const p = deriveDrillingProgram("horizontal", 14000, "wolfcamp");
+	assert.strictEqual(p.programRisk, "High");
+});
+
+test("estimated days: horizontal = depth / 400", () => {
+	const p = deriveDrillingProgram("horizontal", 8000, "shale");
+	assert.strictEqual(p.estimatedDays, 20); // ceil(8000/400)
+});
+
+test("estimated days: vertical = depth / 600", () => {
+	const p = deriveDrillingProgram("vertical", 6000, "limestone");
+	assert.strictEqual(p.estimatedDays, 10); // ceil(6000/600)
+});
+
+test("horizontal → multi-stage fracturing completion", () => {
+	const p = deriveDrillingProgram("horizontal", 8000, "shale");
+	assert.ok(p.completionType.toLowerCase().includes("frac"));
+});
+
+test("vertical → conventional completion", () => {
+	const p = deriveDrillingProgram("vertical", 5000, "sandstone");
+	assert.ok(p.completionType.toLowerCase().includes("conventional"));
+});
+
+test("casing program has 3 strings", () => {
+	const p = deriveDrillingProgram("vertical", 5000, "sandstone");
+	assert.strictEqual(p.casingProgram.length, 3);
+});
+
+test("mud program mentions formation name", () => {
+	const p = deriveDrillingProgram("vertical", 5000, "sandstone");
+	assert.ok(p.mudProgram.includes("sandstone"));
+});
+
+test("keyConsiderations is non-empty", () => {
+	const p = deriveDrillingProgram("vertical", 5000, "sandstone");
+	assert.ok(p.keyConsiderations.length > 0);
+});
+
+test("horizontal → torque consideration in keyConsiderations", () => {
+	const p = deriveDrillingProgram("horizontal", 8000, "shale");
+	assert.ok(p.keyConsiderations.some((c) => c.includes("torque")));
+});
+
+test("deep → pore pressure in keyConsiderations", () => {
+	const p = deriveDrillingProgram("vertical", 14000, "granite");
+	assert.ok(p.keyConsiderations.some((c) => c.includes("pore pressure")));
+});
+
+// ── deriveWellCostBreakdown ───────────────────────────────────────────────────
+
+console.log("\n=== WellCostBreakdown ===\n");
+
+test("horizontal drilling cost = depth × $180/ft", () => {
+	const c = deriveWellCostBreakdown("horizontal", 10000);
+	assert.strictEqual(c.drillingCost, 10000 * 180);
+});
+
+test("directional drilling cost = depth × $140/ft", () => {
+	const c = deriveWellCostBreakdown("directional", 10000);
+	assert.strictEqual(c.drillingCost, 10000 * 140);
+});
+
+test("vertical drilling cost = depth × $120/ft", () => {
+	const c = deriveWellCostBreakdown("vertical", 10000);
+	assert.strictEqual(c.drillingCost, 10000 * 120);
+});
+
+test("completion cost = 60% of drilling cost", () => {
+	const c = deriveWellCostBreakdown("vertical", 10000);
+	assert.strictEqual(c.completionCost, Math.round(c.drillingCost * 0.6));
+});
+
+test("facilities cost = 20% of drilling cost", () => {
+	const c = deriveWellCostBreakdown("vertical", 10000);
+	assert.strictEqual(c.facilitiesCost, Math.round(c.drillingCost * 0.2));
+});
+
+test("horizontal costs more than vertical at same depth", () => {
+	const h = deriveWellCostBreakdown("horizontal", 10000);
+	const v = deriveWellCostBreakdown("vertical", 10000);
+	assert.ok(h.totalCost > v.totalCost);
+});
+
+test("costPerFoot matches well type rate", () => {
+	const c = deriveWellCostBreakdown("horizontal", 10000);
+	assert.strictEqual(c.costPerFoot, 180);
+});
+
+// ── deriveDrillingRiskProfile ─────────────────────────────────────────────────
+
+console.log("\n=== DrillingRiskProfile ===\n");
+
+test("shale formation → geological Medium", () => {
+	const r = deriveDrillingRiskProfile("vertical", 5000, "wolfcamp shale", []);
+	assert.strictEqual(r.geologicalRisk, "Medium");
+});
+
+test("sandstone formation → geological Low", () => {
+	const r = deriveDrillingRiskProfile("vertical", 5000, "sandstone", []);
+	assert.strictEqual(r.geologicalRisk, "Low");
+});
+
+test("deep horizontal → operational High", () => {
+	const r = deriveDrillingRiskProfile("horizontal", 14000, "sandstone", []);
+	assert.strictEqual(r.operationalRisk, "High");
+});
+
+test("shallow vertical → operational Low", () => {
+	const r = deriveDrillingRiskProfile("vertical", 5000, "sandstone", []);
+	assert.strictEqual(r.operationalRisk, "Low");
+});
+
+test("environmental constraints present → environmental Medium", () => {
+	const r = deriveDrillingRiskProfile("vertical", 5000, "sandstone", ["wetlands within 500ft"]);
+	assert.strictEqual(r.environmentalRisk, "Medium");
+});
+
+test("no constraints → environmental Low", () => {
+	const r = deriveDrillingRiskProfile("vertical", 5000, "sandstone", []);
+	assert.strictEqual(r.environmentalRisk, "Low");
+});
+
+test("overallRisk is highest of the three sub-risks", () => {
+	const r = deriveDrillingRiskProfile("horizontal", 14000, "shale", ["wetlands"]);
+	// operational=High, geological=Medium, environmental=Medium → overall=High
+	assert.strictEqual(r.overallRisk, "High");
+});
+
+test("mitigations is non-empty", () => {
+	const r = deriveDrillingRiskProfile("vertical", 5000, "sandstone", []);
+	assert.ok(r.mitigations.length > 0);
+});
+
+test("horizontal well → torque mitigation included", () => {
+	const r = deriveDrillingRiskProfile("horizontal", 8000, "sandstone", []);
+	assert.ok(r.mitigations.some((m) => m.toLowerCase().includes("torque")));
+});
+
+test("environmental constraints → compliance mitigation included", () => {
+	const r = deriveDrillingRiskProfile("vertical", 5000, "sandstone", ["wetlands"]);
+	assert.ok(r.mitigations.some((m) => m.toLowerCase().includes("compliance")));
+});
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

- **Step A — `servers/drilling`**: Refactored monolithic `index.ts` into 3 focused domain modules (`src/tools/program.ts`, `src/tools/costs.ts`, `src/tools/risks.ts`). Added two new MCP tools: `estimate_well_costs` and `assess_drilling_risks`. Backward-compat shims preserved for existing tests. 30 unit tests in `tests/tools.test.ts` (no API key required).
- **Step B — `agents/drilling-engineer`**: Full Tier 2 agent implementation — `drillingEngineerManifest` (3 tools, port 3003), `drillingEngineerConfig`, `runDrillingEngineerTask()` Layer 2 LLM execution loop, `drilling-client.ts` MCP HTTP client. 13 + 34 contract tests, all passing without a live server.
- All 91 tests passing: 14 existing server tests + 30 new domain tests + 13 mcp-client tests + 34 agent contract tests.

## Test plan

- [ ] `cd servers/drilling && npx tsx tests/server.test.ts` — 14 passed
- [ ] `cd servers/drilling && npx tsx tests/tools.test.ts` — 30 passed
- [ ] `cd agents/drilling-engineer && npx tsx tests/mcp-client.test.ts` — 13 passed
- [ ] `cd agents/drilling-engineer && npx tsx tests/agent.test.ts` — 34 passed
- [ ] Integration (optional): `cd servers/drilling && PORT=3003 pnpm start` then re-run mcp-client.test.ts with `ANTHROPIC_API_KEY` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)