### PR TITLE
feat(legal): split legal server + implement legal-analyst Tier 2 agent (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **legal / legal-analyst pair — Steps A + B** (#370) — Tier 1 server modularization and Tier 2 agent for oil & gas legal analysis.
+  - `servers/legal/src/tools/` — 3 domain modules: `regulatory.ts` (jurisdiction risk + permit planning), `contract.ts` (JOA/lease/farmout risk classification), `compliance.ts` (environmental/safety/tax requirements); `tests/tools.test.ts` (32 tests)
+  - `agents/legal-analyst/src/agent/` — manifest (3 tools, port 3006), runtime config, `runLegalAnalystTask()` Layer 2 loop, legal MCP HTTP client; `tests/mcp-client.test.ts` (12) + `tests/agent.test.ts` (41)
+
 - **title / title-analyst pair — Steps A + B** (#372) — Full Tier 1 server modularization and Tier 2 agent implementation for oil & gas title analysis.
   - `servers/title/src/tools/` — 4 focused modules (ownership, lease-analysis, burden-check, chain-of-title) with LLM synthesis + deterministic fallbacks; `tests/tools.test.ts` (22 tests)
   - `agents/title-analyst/src/agent/` — manifest (4 tools, port 3010), runtime config, `runTitleAnalystTask()` Layer 2 loop, title MCP HTTP client; `tests/mcp-client.test.ts` (13) + `tests/agent.test.ts` (31)

--- a/agents/legal-analyst/CHANGELOG.md
+++ b/agents/legal-analyst/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog — @shaleyeah/legal-analyst
+
+## [Unreleased]
+
+## [0.1.0] — 2026-06-10
+
+### Added
+- Tier 2 legal analyst agent with `runLegalAnalystTask` Layer 2 execution loop (#370)
+- `legalAnalystManifest` — 3 tools: `analyze_legal_framework`, `review_contract`, `assess_compliance`
+- `legalAnalystConfig` — runtime config with HITL gate, evals, model routing, legal MCP server at port 3006
+- `callLegalTool` — MCP HTTP client with 30s timeout, retryable/permanent error classification (Arcade #28, #39, #40)
+- `createLegalAnalystRuntime` / `createLegalAnalystEndpoint` factory functions
+- `agents/legal-analyst/tests/mcp-client.test.ts` — 12 tests (Layer 1 + Layer 2 wiring)
+- `agents/legal-analyst/tests/agent.test.ts` — 41 contract tests (manifest, HITL, discovery, evals, health)

--- a/agents/legal-analyst/package.json
+++ b/agents/legal-analyst/package.json
@@ -1,19 +1,25 @@
 {
   "name": "@shaleyeah/legal-analyst",
   "version": "0.1.0",
-  "description": "Legal Analyst — Tier 2 intelligence layer for legal review",
+  "description": "Legal Analyst — Tier 2 intelligence layer for legal review and regulatory analysis",
   "private": true,
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/agent/index.js",
   "scripts": {
     "build": "tsc",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "npx tsx tests/mcp-client.test.ts && npx tsx tests/agent.test.ts",
+    "lint": "biome check src/ tests/",
+    "start": "node dist/agent/index.js"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@shaleyeah/sdk": "workspace:*"
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
     "@types/node": "^25.6.0",
+    "tsx": "^4.19.4",
     "typescript": "^6.0.2"
   }
 }

--- a/agents/legal-analyst/src/agent/index.ts
+++ b/agents/legal-analyst/src/agent/index.ts
@@ -1,0 +1,435 @@
+import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
+import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import { callLegalTool } from "./legal-client.js";
+
+export { callLegalTool };
+
+export const legalAnalystManifest: AgentManifest = {
+	id: "legal-analyst",
+	role: "legal-analyst",
+	version: "0.1.0",
+	description:
+		"Legatus Juridicus — standalone legal analyst agent backed by the legal MCP server. Reviews regulatory exposure, contract terms, and compliance requirements for oil & gas projects.",
+	persona: {
+		name: "Legatus Juridicus",
+		role: "Master Legal Strategist",
+		expertise: [
+			"Regulatory compliance assessment and risk analysis",
+			"Oil & gas contract review and negotiation",
+			"Environmental, safety, and tax compliance",
+			"Permitting and approval timeline planning",
+			"Lease, JOA, and farmout agreement analysis",
+		],
+	},
+	capabilities: [
+		"regulatory-analysis",
+		"contract-review",
+		"compliance-assessment",
+		"permit-planning",
+		"legal-risk-analysis",
+		"model-routing",
+		"evals",
+	],
+	tools: [
+		{
+			name: "legal-analyst.analyze_legal_framework",
+			description: "Analyze regulatory and legal exposure for a jurisdiction and project type.",
+			type: "query",
+			capabilities: ["regulatory-analysis", "legal-risk-analysis"],
+			inputSchema: {
+				type: "object",
+				properties: {
+					jurisdiction: { type: "string", description: "State or jurisdiction (e.g. Texas, California)" },
+					projectType: {
+						type: "string",
+						enum: ["exploration", "development", "production", "abandonment"],
+						description: "Stage of the oil & gas project",
+					},
+					assets: {
+						type: "array",
+						items: { type: "string" },
+						description: "List of asset names or descriptions",
+					},
+					timeline: { type: "string", description: "Optional project timeline description" },
+				},
+				required: ["jurisdiction", "projectType", "assets"],
+			},
+			readOnly: true,
+			destructive: false,
+			requiresHumanApproval: false,
+			requiredScopes: ["read:legal"],
+			modelRequirement: "standard-analysis",
+			evalProfile: "legal-analyst-regulatory",
+			mcpServer: "legal",
+		},
+		{
+			name: "legal-analyst.review_contract",
+			description: "Review and assess risk in oil & gas contract terms.",
+			type: "query",
+			capabilities: ["contract-review", "legal-risk-analysis"],
+			inputSchema: {
+				type: "object",
+				properties: {
+					contractType: {
+						type: "string",
+						enum: ["lease", "JOA", "purchase", "service", "farmout"],
+						description: "Type of oil & gas contract",
+					},
+					keyTerms: {
+						type: "array",
+						items: { type: "string" },
+						description: "Key contract terms and clauses to review",
+					},
+					parties: {
+						type: "array",
+						items: { type: "string" },
+						description: "Contracting parties",
+					},
+					riskProfile: {
+						type: "string",
+						enum: ["conservative", "moderate", "aggressive"],
+						description: "Risk tolerance of the reviewing party",
+					},
+				},
+				required: ["contractType", "keyTerms", "parties"],
+			},
+			readOnly: true,
+			destructive: false,
+			requiresHumanApproval: false,
+			requiredScopes: ["read:legal"],
+			modelRequirement: "standard-analysis",
+			evalProfile: "legal-analyst-contract",
+			mcpServer: "legal",
+		},
+		{
+			name: "legal-analyst.assess_compliance",
+			description: "Assess environmental, safety, and tax compliance requirements for a project.",
+			type: "query",
+			capabilities: ["compliance-assessment", "permit-planning"],
+			inputSchema: {
+				type: "object",
+				properties: {
+					jurisdiction: { type: "string", description: "State or jurisdiction" },
+					projectType: {
+						type: "string",
+						enum: ["exploration", "development", "production", "abandonment"],
+					},
+					assetCount: { type: "number", description: "Number of assets in the project" },
+				},
+				required: ["jurisdiction", "projectType", "assetCount"],
+			},
+			readOnly: true,
+			destructive: false,
+			requiresHumanApproval: false,
+			requiredScopes: ["read:legal"],
+			modelRequirement: "standard-analysis",
+			evalProfile: "legal-analyst-compliance",
+			mcpServer: "legal",
+		},
+	],
+	requiredScopes: ["read:legal"],
+	providerRequirements: [
+		{
+			type: "llm",
+			required: true,
+			description: "Anthropic Claude — standard analysis for regulatory and contract synthesis.",
+		},
+	],
+	compatibility: {
+		agentRuntime: "0.1",
+		remoteEndpoint: "0.1",
+		mcp: "2025-06",
+	},
+	health: {
+		readinessChecks: ["manifest", "runtime-config", "tool-handlers", "model-routing"],
+	},
+	memory: {
+		namespace: "legal-analyst",
+		reviewRequired: true,
+		sharedMemoryOptIn: false,
+	},
+	evals: {
+		defaultProfile: "legal-analyst-default",
+		requiredChecks: ["schema", "redactSecrets"],
+	},
+	autonomy: {
+		defaultLevel: "reviewed",
+		allowedLevels: ["assistive", "reviewed", "autonomous"],
+	},
+};
+
+export const legalAnalystConfig: AgentRuntimeConfig = {
+	autonomy: "reviewed",
+	modelRouting: {
+		"small-fast": { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+		"standard-analysis": { provider: "anthropic", model: "claude-sonnet-4-6" },
+		"deep-reasoning": { provider: "anthropic", model: "claude-opus-4-8" },
+		"local-private": { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+		deterministic: { provider: "rule-based", model: "no-model" },
+	},
+	hitl: {
+		approvalMode: "when-sensitive",
+		requireForDestructive: true,
+		requireForMemoryPromotion: true,
+	},
+	evals: {
+		enabled: true,
+		profile: "legal-analyst-default",
+		checks: {
+			schema: "blocking",
+			domainCompleteness: "advisory",
+			confidenceMinimum: 0.7,
+			requireSources: false,
+			redactSecrets: "blocking",
+			memoryPromotion: "reviewed-only",
+		},
+	},
+	memory: {
+		enabled: true,
+		namespace: "legal-analyst",
+		vectorStore: { enabled: false },
+		retentionDays: 90,
+		promotion: {
+			requireHumanReview: true,
+			allowSharedMemory: false,
+		},
+	},
+	mcpServers: {
+		legal: {
+			url: process.env.LEGAL_MCP_URL ?? "http://localhost:3006",
+			transport: "http",
+			authType: "none",
+		},
+	},
+	dataConnectors: {},
+};
+
+function legalUrl(config: AgentRuntimeConfig): string {
+	return config.mcpServers?.legal?.url ?? "http://localhost:3006";
+}
+
+const handlers: Record<string, StandaloneToolHandler> = {
+	"legal-analyst.analyze_legal_framework": ({ args, config }) =>
+		callLegalTool(legalUrl(config), "analyze_legal_framework", args as Record<string, unknown>),
+
+	"legal-analyst.review_contract": ({ args, config }) =>
+		callLegalTool(legalUrl(config), "review_contract", args as Record<string, unknown>),
+
+	"legal-analyst.assess_compliance": ({ args, config }) =>
+		callLegalTool(legalUrl(config), "assess_compliance", args as Record<string, unknown>),
+};
+
+export function createLegalAnalystRuntime(config: AgentRuntimeConfig = legalAnalystConfig): LocalAgentRuntime {
+	return new LocalAgentRuntime({
+		manifest: legalAnalystManifest,
+		config,
+		handlers,
+	});
+}
+
+export function createLegalAnalystEndpoint(config: AgentRuntimeConfig = legalAnalystConfig): LocalAgentEndpoint {
+	return new LocalAgentEndpoint(createLegalAnalystRuntime(config));
+}
+
+/**
+ * Run a multi-step legal analysis task driven by the LLM (Layer 2 execution loop).
+ *
+ * Accepts a natural language goal, reasons about which legal tools to call,
+ * executes them through the governed runtime (HITL + scope checks fire on every
+ * tool call — Arcade pattern #46: Permission Gate), and returns a synthesized answer.
+ *
+ * options.runtime    — caller-managed runtime (e.g. in tests)
+ * options.onApprovalRequired — HITL callback; throws if omitted and approval is required
+ *
+ * Deferred (#395): Context Injection — read/write memory namespace around the loop.
+ * Deferred (#396): Async Job — polling for long-running legal analyses.
+ */
+export async function runLegalAnalystTask(
+	goal: string,
+	options: {
+		config?: AgentRuntimeConfig;
+		apiKey?: string;
+		runtime?: LocalAgentRuntime;
+		onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+	} = {},
+): Promise<string> {
+	const config = options.config ?? legalAnalystConfig;
+
+	let runtime = options.runtime;
+	let ownedRuntime = false;
+	if (!runtime) {
+		runtime = createLegalAnalystRuntime(config);
+		await runtime.initialize();
+		ownedRuntime = true;
+	}
+
+	try {
+		return await executeLoop(goal, runtime, { ...options, config });
+	} finally {
+		if (ownedRuntime) await runtime.shutdown();
+	}
+}
+
+function buildTranscript(history: Array<{ role: "user" | "assistant" | "tool"; content: string }>): string {
+	return history
+		.map((t) => {
+			if (t.role === "user") return `User: ${t.content}`;
+			if (t.role === "assistant") return `Assistant: ${t.content}`;
+			return `Tool result: ${t.content}`;
+		})
+		.join("\n\n");
+}
+
+// Retry budgets — Arcade pattern #40: Error Classification.
+const MAX_TOOL_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 500;
+
+async function executeWithRetry(
+	runtime: LocalAgentRuntime,
+	request: Parameters<typeof runtime.execute>[0],
+): Promise<ReturnType<LocalAgentRuntime["execute"]>> {
+	let last: Awaited<ReturnType<LocalAgentRuntime["execute"]>> | null = null;
+	for (let attempt = 0; attempt <= MAX_TOOL_RETRIES; attempt++) {
+		if (attempt > 0) {
+			await new Promise((r) => setTimeout(r, RETRY_BASE_DELAY_MS * 2 ** (attempt - 1)));
+		}
+		const result = await runtime.execute(request);
+		if (result.status !== "failed" || !result.retryable) return result;
+		last = result;
+	}
+	return last!;
+}
+
+function parseJson(
+	text: string,
+): { action?: string; tool?: string; args?: Record<string, unknown>; answer?: string } | null {
+	try {
+		const cleaned = text
+			.replace(/^```(?:json)?\s*/m, "")
+			.replace(/\s*```\s*$/m, "")
+			.trim();
+		return JSON.parse(cleaned);
+	} catch {
+		return null;
+	}
+}
+
+async function executeLoop(
+	goal: string,
+	runtime: LocalAgentRuntime,
+	options: {
+		config?: AgentRuntimeConfig;
+		apiKey?: string;
+		onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+	},
+): Promise<string> {
+	// TODO (#395): Context Injection — read from memory.namespace before building system prompt.
+
+	const config = options.config ?? legalAnalystConfig;
+	const reasoningModel = config.modelRouting["standard-analysis"]?.model;
+
+	const toolDefs = legalAnalystManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+
+	const system = `You are ${legalAnalystManifest.persona.name}, ${legalAnalystManifest.persona.role}.
+
+Available tools:
+${toolDefs}
+
+Respond ONLY with valid JSON — no prose, no markdown. Two formats allowed:
+1. Call a tool:  {"action":"tool","tool":"<full tool name>","args":{...}}
+2. Final answer: {"action":"done","answer":"<synthesized answer>"}
+
+Always use the full tool name (e.g. "legal-analyst.analyze_legal_framework").
+If you cannot complete the task with the available tools, respond with {"action":"done","answer":"<explanation>"}.`;
+
+	type Turn = { role: "user" | "assistant" | "tool"; content: string };
+	const history: Turn[] = [{ role: "user", content: goal }];
+	const MAX_STEPS = 8;
+
+	for (let step = 0; step < MAX_STEPS; step++) {
+		const response = await callLLM({
+			system,
+			prompt: `${buildTranscript(history)}\n\nAssistant:`,
+			model: reasoningModel,
+			apiKey: options.apiKey,
+		});
+
+		history.push({ role: "assistant", content: response });
+
+		const parsed = parseJson(response);
+		if (!parsed || parsed.action === "done" || !parsed.tool) {
+			return parsed?.answer ?? response;
+		}
+
+		// TODO (#396): Async Job — detect long-running legal analyses and poll for completion.
+
+		// Permission Gate: route through runtime.execute() so HITL + scope checks fire.
+		const execResult = await executeWithRetry(runtime, {
+			toolName: parsed.tool,
+			args: parsed.args ?? {},
+			runId: `task:step:${step}`,
+		});
+
+		if (execResult.status === "completed") {
+			history.push({ role: "tool", content: JSON.stringify(execResult.data) });
+		} else if (execResult.status === "approval_required") {
+			if (!options.onApprovalRequired) {
+				throw new Error(
+					`Tool ${parsed.tool} requires human approval. ` +
+						"Provide an onApprovalRequired callback to runLegalAnalystTask, or set autonomy to 'autonomous'.",
+				);
+			}
+			const approval = await options.onApprovalRequired(execResult.challenge);
+			const approved = await runtime.execute({
+				toolName: parsed.tool,
+				args: parsed.args ?? {},
+				approval,
+				runId: `task:step:${step}:approved`,
+			});
+			if (approved.status === "completed") {
+				history.push({ role: "tool", content: JSON.stringify(approved.data) });
+			} else {
+				const err = approved.status === "failed" ? approved.error : "approval re-execution failed";
+				history.push({ role: "tool", content: `Error after approval for ${parsed.tool}: ${err}` });
+			}
+		} else {
+			const hint = execResult.retryable ? " (retryable — server may be temporarily unavailable)" : " (permanent)";
+			history.push({ role: "tool", content: `Error calling ${parsed.tool}: ${execResult.error}${hint}` });
+		}
+	}
+
+	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+
+	const finalResponse = await callLLM({
+		system,
+		prompt: `${buildTranscript(history)}\n\nUser: Maximum steps reached. Synthesize findings now.\n\nAssistant:`,
+		model: reasoningModel,
+		apiKey: options.apiKey,
+	});
+
+	return parseJson(finalResponse)?.answer ?? finalResponse;
+}
+
+// ── CLI entrypoint ────────────────────────────────────────────────────────────
+import { fileURLToPath } from "node:url";
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+	const goal = process.argv.slice(2).join(" ").trim();
+	if (!goal) {
+		console.error("Usage: npx tsx src/agent/index.ts <goal>");
+		console.error('  Example: npx tsx src/agent/index.ts "Analyze legal exposure for Texas exploration project"');
+		process.exit(1);
+	}
+	const answer = await runLegalAnalystTask(goal, {
+		onApprovalRequired: async (challenge) => {
+			console.log(`\n⏸  Approval required for: ${challenge.toolName}`);
+			console.log(`   Reason: ${challenge.reason ?? "tool requires human review"}`);
+			console.log("   Auto-approving in CLI mode...\n");
+			return { approved: true, reviewerId: "cli", reason: "CLI auto-approve" };
+		},
+	}).catch((err: unknown) => {
+		console.error(err instanceof Error ? err.message : String(err));
+		process.exit(1);
+	});
+	console.log(answer);
+}

--- a/agents/legal-analyst/src/agent/legal-client.ts
+++ b/agents/legal-analyst/src/agent/legal-client.ts
@@ -1,0 +1,61 @@
+/**
+ * Legal MCP client — thin wrapper that connects to the legal Tier 1 server over HTTP,
+ * calls a single tool, and closes the connection.
+ *
+ * One-shot per call: simpler than managing a persistent connection for a standalone agent
+ * that may not run co-located with the legal server at all times.
+ *
+ * Implements Arcade patterns:
+ *   #28 Timeout Boundary — configurable timeoutMs, default 30s
+ *   #39 Recovery Guide   — error messages include tool name and cause
+ *   #40 Error Classification — RetryableToolError vs PermanentToolError
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { PermanentToolError, RetryableToolError } from "@shaleyeah/sdk";
+
+export async function callLegalTool(
+	url: string,
+	toolName: string,
+	args: Record<string, unknown>,
+	options: { timeoutMs?: number } = {},
+): Promise<unknown> {
+	const timeoutMs = options.timeoutMs ?? 30_000;
+
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	const timeoutPromise = new Promise<never>((_, reject) => {
+		timeout = setTimeout(
+			() => reject(new RetryableToolError(`Tool call to ${toolName} timed out after ${timeoutMs}ms`)),
+			timeoutMs,
+		);
+	});
+
+	const callPromise = (async () => {
+		const transport = new StreamableHTTPClientTransport(new URL(url));
+		const client = new Client({ name: "legal-analyst", version: "0.1.0" });
+		await client.connect(transport);
+		try {
+			const result = await client.callTool({ name: toolName, arguments: args });
+			return result.content;
+		} finally {
+			await client.close().catch(() => {});
+		}
+	})();
+
+	try {
+		return await Promise.race([callPromise, timeoutPromise]);
+	} catch (err) {
+		if (err instanceof RetryableToolError || err instanceof PermanentToolError) throw err;
+
+		const msg = err instanceof Error ? err.message : String(err);
+
+		if (/ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENETUNREACH|fetch failed/i.test(msg)) {
+			throw new RetryableToolError(`Network error calling ${toolName}: ${msg}`, err instanceof Error ? err : undefined);
+		}
+
+		throw new PermanentToolError(`Tool call to ${toolName} failed: ${msg}`, err instanceof Error ? err : undefined);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}

--- a/agents/legal-analyst/src/index.ts
+++ b/agents/legal-analyst/src/index.ts
@@ -1,20 +1,2 @@
-/**
- * Legal Analyst Agent — stub, migration tracked in issue #370
- *
- * Implementation guide: .claude/rules/agent-template.md
- * Reference implementation: agents/geologist/src/agent/index.ts
- *
- * When implemented:
- *   src/agent/index.ts           — manifest + config + handlers + runLegalAnalystTask
- *   src/agent/legal-client.ts    — callLegalTool (copy geowiz-client.ts, rename)
- *   tests/mcp-client.test.ts     — copy geologist mcp-client.test.ts
- *   tests/agent.test.ts          — copy geologist agent.test.ts
- *
- * Target server: legal (servers/legal, default port 3006)
- * Env var: LEGAL_MCP_URL
- */
-
 export const AGENT_ID = "legal-analyst";
-
-// Uncomment and switch to this export once src/agent/index.ts is implemented:
-// export * from "./agent/index.js";
+export * from "./agent/index.js";

--- a/agents/legal-analyst/tests/agent.test.ts
+++ b/agents/legal-analyst/tests/agent.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Legal Analyst Agent Contract Tests — Issue #370
+ *
+ * Proves the legal tools are accessible through the AgentRuntime contract
+ * and that the legal-analyst manifest satisfies all Arcade acceptance criteria.
+ */
+
+import { AgentManifestSchema, AgentRuntimeConfigSchema, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	createLegalAnalystEndpoint,
+	createLegalAnalystRuntime,
+	legalAnalystConfig,
+	legalAnalystManifest,
+} from "../src/agent/index.js";
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, message: string): void {
+	if (condition) {
+		console.log(`  ✅ ${message}`);
+		passed++;
+	} else {
+		console.error(`  ❌ ${message}`);
+		failed++;
+	}
+}
+
+console.log("🧪 Starting Legal Analyst Agent Contract Tests (#370)\n");
+
+console.log("📋 Testing manifest and config validation...");
+{
+	const manifest = AgentManifestSchema.safeParse(legalAnalystManifest);
+	assert(manifest.success, "Legal analyst manifest validates");
+	if (!manifest.success) console.error("  ", manifest.error.format());
+
+	const config = AgentRuntimeConfigSchema.safeParse(legalAnalystConfig);
+	assert(config.success, "Legal analyst runtime config validates");
+
+	assert(legalAnalystManifest.id === "legal-analyst", "Agent id is legal-analyst");
+	assert(legalAnalystManifest.persona.name === "Legatus Juridicus", "Persona is Legatus Juridicus");
+	assert(legalAnalystManifest.tools.length === 3, "Legal analyst exposes 3 legal tools");
+	assert(
+		legalAnalystManifest.tools.every((t) => t.name.startsWith("legal-analyst.")),
+		"All tools follow legal-analyst. naming convention",
+	);
+	assert(
+		legalAnalystManifest.tools.every((t) => !t.modelRequirement.includes("claude")),
+		"Model requirements are capability labels, not provider names",
+	);
+	assert(
+		legalAnalystManifest.tools.every((t) => t.inputSchema && typeof t.inputSchema === "object"),
+		"All tools declare explicit input schemas",
+	);
+	assert(
+		legalAnalystManifest.tools.every((t) => t.mcpServer === "legal"),
+		'All tools declare mcpServer: "legal"',
+	);
+	const allToolScopes = new Set(legalAnalystManifest.tools.flatMap((t) => t.requiredScopes));
+	assert(
+		[...allToolScopes].every((s) => legalAnalystManifest.requiredScopes.includes(s)),
+		"Manifest requiredScopes is a superset of all tool requiredScopes",
+	);
+	const llmReq = legalAnalystManifest.providerRequirements.find((p) => p.type === "llm");
+	assert(llmReq?.required === true, "LLM provider requirement is marked required");
+}
+
+console.log("\n🔎 Testing progressive discovery...");
+{
+	const runtime = createLegalAnalystRuntime();
+	await runtime.initialize();
+
+	const summary = runtime.discover("summary");
+	assert("capabilities" in summary, "Summary discovery returns capabilities");
+	assert(!("tools" in summary), "Summary discovery does not include tool list");
+
+	const tools = runtime.discover("tools");
+	assert(Array.isArray(tools) && tools.length === 3, "Tool discovery returns 3 tools");
+	assert(!("inputSchema" in tools[0]), "Tool list omits input schemas");
+
+	const schema = runtime.discover("schema", "legal-analyst.analyze_legal_framework");
+	assert(schema?.inputSchema !== undefined, "Schema discovery returns analyze_legal_framework input schema");
+	assert(
+		(schema?.inputSchema as Record<string, unknown>)?.required !== undefined,
+		"analyze_legal_framework schema declares required fields",
+	);
+
+	const missing = runtime.discover("schema", "legal-analyst.nonexistent");
+	assert(missing === null, "Schema discovery returns null for unknown tool");
+
+	await runtime.shutdown();
+}
+
+console.log("\n🧭 Testing organization-owned model routing...");
+{
+	const customRouting = {
+		...legalAnalystConfig.modelRouting,
+		"standard-analysis": {
+			provider: "acme-legal-llm",
+			model: "operator-selected-model",
+		},
+	};
+
+	const analysisTool = legalAnalystManifest.tools.find((t) => t.name === "legal-analyst.analyze_legal_framework");
+	assert(analysisTool !== undefined, "analyze_legal_framework tool is declared in manifest");
+
+	const deterministicRoute = legalAnalystConfig.modelRouting.deterministic;
+	assert(deterministicRoute !== undefined, "Deterministic route is configured");
+	assert(deterministicRoute.provider === "rule-based", "Deterministic tools use rule-based provider");
+
+	const overrideRoute = customRouting["standard-analysis"];
+	assert(overrideRoute.provider === "acme-legal-llm", "Operator override populates provider");
+	assert(overrideRoute.model === "operator-selected-model", "Operator override populates model");
+}
+
+console.log("\n📡 Testing model capability routing across requirement classes...");
+{
+	const runtime = createLegalAnalystRuntime();
+	await runtime.initialize();
+
+	const modelRequirements = new Set(legalAnalystManifest.tools.map((t) => t.modelRequirement));
+	assert(modelRequirements.has("standard-analysis"), "standard-analysis requirement present in tool suite");
+
+	for (const req of modelRequirements) {
+		const binding = legalAnalystConfig.modelRouting[req];
+		assert(binding !== undefined, `Model route exists for requirement: ${req}`);
+	}
+
+	const standardBinding = legalAnalystConfig.modelRouting["standard-analysis"];
+	assert(
+		typeof standardBinding?.model === "string" && standardBinding.model.length > 0,
+		"standard-analysis model binding is a real model ID",
+	);
+
+	await runtime.shutdown();
+}
+
+console.log("\n🙋 Testing HITL policy wires through to config...");
+{
+	const approvalRequired = legalAnalystManifest.tools.filter((t) => t.requiresHumanApproval);
+	assert(approvalRequired.length === 0, "No legal-analyst tool requires human approval by default");
+
+	const strictRuntime = createLegalAnalystRuntime({
+		...legalAnalystConfig,
+		hitl: { ...legalAnalystConfig.hitl, approvalMode: "always" },
+	});
+	await strictRuntime.initialize();
+	const blocked = await strictRuntime.execute({
+		toolName: "legal-analyst.assess_compliance",
+		args: { jurisdiction: "Texas", projectType: "production", assetCount: 2 },
+	});
+	assert(blocked.status === "approval_required", "approvalMode: 'always' blocks all tools");
+	if (blocked.status === "approval_required") {
+		assert(blocked.challenge.type === "human_approval_required", "Challenge is structured");
+		assert(blocked.challenge.agentId === "legal-analyst", "Challenge identifies legal-analyst agent");
+	}
+
+	await strictRuntime.shutdown();
+}
+
+console.log("\n🧪 Testing evals policy is configured correctly...");
+{
+	assert(legalAnalystConfig.evals.enabled === true, "Evals are enabled");
+	assert(legalAnalystConfig.evals.checks.schema === "blocking", "Schema eval is blocking");
+	assert(legalAnalystConfig.evals.checks.redactSecrets === "blocking", "Secret-redaction eval is blocking");
+
+	const profileTools = legalAnalystManifest.tools.filter((t) => t.evalProfile);
+	assert(profileTools.length === 3, "All legal-analyst tools declare eval profiles");
+	assert(
+		profileTools.every((t) => typeof t.evalProfile === "string"),
+		"All declared eval profiles are strings",
+	);
+}
+
+console.log("\n🏥 Testing health endpoint and standalone boot...");
+{
+	const endpoint = createLegalAnalystEndpoint();
+	const health = await endpoint.health();
+	assert(health.agentId === "legal-analyst", "Health endpoint identifies legal-analyst");
+	assert(health.status !== "not_ready", "Legal analyst boots without external dependencies");
+
+	const manifest = await endpoint.manifest();
+	assert(manifest.id === "legal-analyst", "Endpoint exposes legal-analyst manifest");
+	assert(manifest.tools.length === 3, "Endpoint manifest has 3 tools");
+
+	const toolSchema = await endpoint.discoveryToolSchema("legal-analyst.analyze_legal_framework");
+	assert(toolSchema !== null, "Endpoint exposes tool schemas by name");
+}
+
+console.log("\n🛑 Testing invalid manifest fails early...");
+{
+	try {
+		new LocalAgentRuntime({
+			manifest: { ...legalAnalystManifest, id: "" } as typeof legalAnalystManifest,
+			config: legalAnalystConfig,
+			handlers: Object.fromEntries(legalAnalystManifest.tools.map((t) => [t.name, async () => ({})])),
+		});
+		assert(false, "Empty manifest id should fail validation");
+	} catch {
+		assert(true, "Invalid manifest id fails at construction");
+	}
+}
+
+console.log("\n══════════════════════════════════════════════");
+console.log(`Legal Analyst Agent Contract Tests: ${passed} passed, ${failed} failed`);
+console.log("══════════════════════════════════════════════");
+
+if (failed > 0) {
+	process.exit(1);
+}

--- a/agents/legal-analyst/tests/mcp-client.test.ts
+++ b/agents/legal-analyst/tests/mcp-client.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Legal Analyst MCP Client + runTask Tests — Issue #370
+ *
+ * Layer 1: verifies callLegalTool delegates to legal server over HTTP.
+ * Layer 2: verifies runLegalAnalystTask drives a multi-step LLM loop.
+ *
+ * Run: cd agents/legal-analyst && npx tsx tests/mcp-client.test.ts
+ */
+
+import assert from "node:assert";
+import type { HumanApprovalChallenge } from "@shaleyeah/sdk";
+import { PermanentToolError, RetryableToolError } from "@shaleyeah/sdk";
+import {
+	callLegalTool,
+	createLegalAnalystRuntime,
+	legalAnalystConfig,
+	legalAnalystManifest,
+	runLegalAnalystTask,
+} from "../src/agent/index.js";
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void | Promise<void>): Promise<void> {
+	return Promise.resolve()
+		.then(fn)
+		.then(() => {
+			console.log(`  ✓ ${name}`);
+			passed++;
+		})
+		.catch((err: unknown) => {
+			console.log(`  ✗ ${name}`);
+			console.log(`    ${err instanceof Error ? err.message : String(err)}`);
+			failed++;
+		});
+}
+
+async function legalReachable(): Promise<boolean> {
+	try {
+		const url = legalAnalystConfig.mcpServers?.legal?.url ?? "http://localhost:3006";
+		const ctrl = new AbortController();
+		const timer = setTimeout(() => ctrl.abort(), 500);
+		await fetch(url, { method: "HEAD", signal: ctrl.signal });
+		clearTimeout(timer);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function runTests(): Promise<void> {
+	console.log("\n🧪 Legal Analyst MCP Client + runTask Tests (#370)\n");
+
+	await test("callLegalTool is exported as a function", () => {
+		assert.strictEqual(typeof callLegalTool, "function", "callLegalTool must be exported");
+	});
+
+	await test('legalAnalystConfig.mcpServers["legal"].url is http://localhost:3006', () => {
+		const conn = legalAnalystConfig.mcpServers?.legal;
+		assert.ok(conn, 'mcpServers["legal"] entry must be present');
+		assert.strictEqual(conn.url, "http://localhost:3006", "legal URL must be localhost:3006");
+	});
+
+	await test('legalAnalystConfig.mcpServers["legal"].transport is http', () => {
+		const conn = legalAnalystConfig.mcpServers?.legal;
+		assert.ok(conn, 'mcpServers["legal"] entry must be present');
+		assert.strictEqual(conn.transport, "http", "legal transport must be http");
+	});
+
+	await test("all 3 legal-analyst tools declare mcpServer: 'legal'", () => {
+		const wrong = legalAnalystManifest.tools.filter((t) => t.mcpServer !== "legal");
+		assert.strictEqual(wrong.length, 0, `Tools without mcpServer='legal': ${wrong.map((t) => t.name).join(", ")}`);
+	});
+
+	await test("callLegalTool rejects with a clear error when server is unreachable", async () => {
+		let threw = false;
+		try {
+			await callLegalTool("http://localhost:19999", "analyze_legal_framework", {
+				jurisdiction: "Texas",
+				projectType: "production",
+				assets: ["Well A"],
+			});
+		} catch (err) {
+			threw = true;
+			const msg = err instanceof Error ? err.message : String(err);
+			assert.ok(msg.length > 0, "Error message must be non-empty");
+		}
+		assert.ok(threw, "callLegalTool must throw when server is unreachable");
+	});
+
+	await test("runLegalAnalystTask is exported as a function", () => {
+		assert.strictEqual(typeof runLegalAnalystTask, "function", "runLegalAnalystTask must be exported");
+	});
+
+	await test("runLegalAnalystTask throws when no ANTHROPIC_API_KEY is set", async () => {
+		const saved = process.env.ANTHROPIC_API_KEY;
+		delete process.env.ANTHROPIC_API_KEY;
+		let threw = false;
+		try {
+			await runLegalAnalystTask("analyze legal exposure for Texas exploration");
+		} catch (err) {
+			threw = true;
+			const msg = err instanceof Error ? err.message : String(err);
+			assert.ok(msg.includes("ANTHROPIC_API_KEY"), `Error must mention ANTHROPIC_API_KEY, got: ${msg}`);
+		} finally {
+			if (saved !== undefined) process.env.ANTHROPIC_API_KEY = saved;
+		}
+		assert.ok(threw, "runLegalAnalystTask must throw when no API key is set");
+	});
+
+	await test("runLegalAnalystTask hits callLLM when API key is present (auth error confirms path)", async () => {
+		let threw = false;
+		try {
+			await runLegalAnalystTask("analyze legal exposure for Texas exploration", {
+				apiKey: "sk-ant-invalid-key-for-test",
+			});
+		} catch (err) {
+			threw = true;
+			const msg = err instanceof Error ? err.message : String(err);
+			assert.ok(msg.length > 0, "Error from invalid key must have a message");
+		}
+		assert.ok(threw, "runLegalAnalystTask with invalid key must throw (proves callLLM was hit)");
+	});
+
+	await test("RetryableToolError is exported from @shaleyeah/sdk", () => {
+		assert.strictEqual(typeof RetryableToolError, "function");
+		const err = new RetryableToolError("test");
+		assert.strictEqual(err.retryable, true);
+	});
+
+	await test("PermanentToolError is exported from @shaleyeah/sdk", () => {
+		assert.strictEqual(typeof PermanentToolError, "function");
+		const err = new PermanentToolError("test");
+		assert.strictEqual(err.retryable, false);
+	});
+
+	await test("runLegalAnalystTask accepts runtime option (signature check)", () => {
+		const params = runLegalAnalystTask.length;
+		assert.ok(params >= 1, "runLegalAnalystTask must accept at least a goal argument");
+	});
+
+	await test("approvalMode: 'always' returns a structured HITL challenge", async () => {
+		const strictRuntime = createLegalAnalystRuntime({
+			...legalAnalystConfig,
+			hitl: { ...legalAnalystConfig.hitl, approvalMode: "always" },
+		});
+		await strictRuntime.initialize();
+
+		const result = await strictRuntime.execute({
+			toolName: "legal-analyst.analyze_legal_framework",
+			args: { jurisdiction: "Texas", projectType: "production", assets: ["Well A"] },
+		});
+		await strictRuntime.shutdown();
+
+		assert.strictEqual(result.status, "approval_required", "HITL gate must block with approvalMode='always'");
+		assert.ok("challenge" in result, "approval_required result must have a challenge");
+		const challenge = (result as { status: "approval_required"; challenge: HumanApprovalChallenge }).challenge;
+		assert.strictEqual(challenge.toolName, "legal-analyst.analyze_legal_framework");
+		assert.strictEqual(challenge.agentId, "legal-analyst");
+	});
+
+	const live = await legalReachable();
+	if (!live) {
+		console.log("\n  ⚠️  [integration] legal server not reachable at localhost:3006 — skipping live MCP tests.");
+		console.log("     Start with: cd servers/legal && PORT=3006 pnpm start");
+	}
+
+	if (live) {
+		await test("[integration] callLegalTool routes analyze_legal_framework through legal MCP", async () => {
+			const result = await callLegalTool(legalAnalystConfig.mcpServers!.legal.url, "analyze_legal_framework", {
+				jurisdiction: "Texas",
+				projectType: "production",
+				assets: ["Well A-1"],
+			});
+			assert.ok(result !== undefined, "MCP tool call must return a value");
+		});
+	}
+
+	if (live && process.env.ANTHROPIC_API_KEY) {
+		await test("[integration] runLegalAnalystTask completes a multi-step legal task", async () => {
+			const answer = await runLegalAnalystTask(
+				"Analyze the regulatory exposure for a Texas production project with 2 wells.",
+			);
+			assert.strictEqual(typeof answer, "string", "runLegalAnalystTask must return a string");
+			assert.ok(answer.length > 0, "Answer must be non-empty");
+		});
+	} else {
+		console.log("  ⚠️  [integration] ANTHROPIC_API_KEY not set or legal server not running — skipping runTask live test.");
+	}
+
+	console.log(`\nLegal Analyst MCP Client + runTask Tests: ${passed} passed, ${failed} failed`);
+	if (failed > 0) process.exit(1);
+}
+
+await runTests();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,13 +135,22 @@ importers:
 
   agents/legal-analyst:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@shaleyeah/sdk':
         specifier: workspace:*
         version: link:../../sdk
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
       '@types/node':
         specifier: ^25.6.0
         version: 25.9.1
+      tsx:
+        specifier: ^4.19.4
+        version: 4.22.4
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
@@ -652,15 +661,32 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
   '@biomejs/biome@2.4.16':
     resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@biomejs/cli-darwin-arm64@2.4.16':
     resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
     os: [darwin]
 
   '@biomejs/cli-darwin-x64@2.4.16':
@@ -669,12 +695,26 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@biomejs/cli-linux-arm64-musl@2.4.16':
     resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-arm64@2.4.16':
     resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
@@ -683,12 +723,26 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@biomejs/cli-linux-x64-musl@2.4.16':
     resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64@2.4.16':
     resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
@@ -697,10 +751,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
   '@biomejs/cli-win32-arm64@2.4.16':
     resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
     os: [win32]
 
   '@biomejs/cli-win32-x64@2.4.16':
@@ -2069,6 +2135,17 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
+  '@biomejs/biome@1.9.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
+
   '@biomejs/biome@2.4.16':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.4.16
@@ -2080,25 +2157,49 @@ snapshots:
       '@biomejs/cli-win32-arm64': 2.4.16
       '@biomejs/cli-win32-x64': 2.4.16
 
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
+
   '@biomejs/cli-darwin-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.4':
     optional: true
 
   '@biomejs/cli-darwin-x64@2.4.16':
     optional: true
 
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
+
   '@biomejs/cli-linux-arm64-musl@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.4':
     optional: true
 
   '@biomejs/cli-linux-arm64@2.4.16':
     optional: true
 
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
+
   '@biomejs/cli-linux-x64-musl@2.4.16':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.4':
     optional: true
 
   '@biomejs/cli-linux-x64@2.4.16':
     optional: true
 
+  '@biomejs/cli-win32-arm64@1.9.4':
+    optional: true
+
   '@biomejs/cli-win32-arm64@2.4.16':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
   '@biomejs/cli-win32-x64@2.4.16':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,5 @@ packages:
   - 'servers/*'
   - 'orchestrator'
 allowBuilds:
+  '@biomejs/biome': set this to true or false
   esbuild: true

--- a/servers/legal/CHANGELOG.md
+++ b/servers/legal/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-06-10
+
+### Added
+- Split `src/index.ts` into focused domain modules: `src/tools/regulatory.ts`, `src/tools/contract.ts`, `src/tools/compliance.ts` (#370)
+- Added third MCP tool: `assess_compliance` backed by `compliance.ts`
+- `servers/legal/tests/tools.test.ts` — 32 unit tests for domain logic (no API key required)
+- Backward-compat exports preserved so existing tests continue to pass
+
 ## [0.1.0] — 2026-06-04
 
 ### Added

--- a/servers/legal/src/index.ts
+++ b/servers/legal/src/index.ts
@@ -1,96 +1,52 @@
 #!/usr/bin/env node
-
 /**
- * Legal MCP Server - DRY Refactored
- * Legatus Juridicus - Master Legal Strategist
+ * Legal MCP Server — Legatus Juridicus, Master Legal Strategist.
+ * Thin facade — all domain logic lives in src/tools/.
  */
 
-import fs from "node:fs/promises";
-import { callLLM, runMCPServer, ServerFactory, type ServerTemplate, ServerUtils } from "@shaleyeah/sdk";
+import { runMCPServer, ServerFactory, type ServerTemplate, ServerUtils } from "@shaleyeah/sdk";
 import { z } from "zod";
 
+import { deriveRegulatoryAssessment, synthesizeRegulatoryAssessmentWithLLM } from "./tools/regulatory.js";
+import { deriveContractReview, synthesizeContractReviewWithLLM } from "./tools/contract.js";
+import { deriveComplianceRequirements, synthesizeComplianceRequirementsWithLLM } from "./tools/compliance.js";
+
 // ---------------------------------------------------------------------------
-// Exported helpers (used by tests)
+// Backward-compat exports — existing tests import these from ../src/index.js
 // ---------------------------------------------------------------------------
 
-/**
- * Rule-based regulatory risk rating — used as fallback when the API is unavailable.
- * Returns "High" / "Medium" / "Low" based on jurisdiction and project type.
- * Different inputs must produce different outputs so tests can verify determinism.
- */
 export function deriveDefaultRegulatoryRisk(jurisdiction: string, projectType: string): string {
-	const highRiskJurisdictions = ["california", "colorado", "new mexico"];
-	const jLower = jurisdiction.toLowerCase();
-	const isHighJurisdiction = highRiskJurisdictions.some((j) => jLower.includes(j));
-
-	if (projectType === "exploration" || isHighJurisdiction) return "High";
-	if (projectType === "development") return "Medium";
-	return "Low";
+	return deriveRegulatoryAssessment(
+		jurisdiction,
+		projectType as "exploration" | "development" | "production" | "abandonment",
+	).regulatoryRisk;
 }
 
-/**
- * Ask Claude (Legatus Juridicus) to assess the legal and regulatory exposure
- * for a given jurisdiction and project type. Falls back to rule-based risk rating
- * when the API is unavailable.
- */
 export async function synthesizeLegalAnalysisWithLLM(params: {
 	jurisdiction: string;
 	projectType: string;
 	assets: string[];
 }): Promise<{ regulatoryRisk: string; keyRisks: string[]; recommendations: string[] }> {
-	const { jurisdiction, projectType, assets } = params;
-
-	const prompt = `You are Legatus Juridicus, a master oil & gas legal strategist.
-
-Analyze the regulatory and legal exposure for this project and return a JSON object.
-
-PROJECT:
-Jurisdiction: ${jurisdiction}
-Project type: ${projectType}
-Assets: ${assets.join(", ")}
-
-Return ONLY valid JSON in this exact shape:
-{
-  "regulatoryRisk": "High" | "Medium" | "Low",
-  "keyRisks": ["<risk 1>", "<risk 2>", "<risk 3>"],
-  "recommendations": ["<action 1>", "<action 2>", "<action 3>"]
+	return synthesizeRegulatoryAssessmentWithLLM({
+		jurisdiction: params.jurisdiction,
+		projectType: params.projectType as "exploration" | "development" | "production" | "abandonment",
+		assets: params.assets,
+	});
 }
 
-Base your assessment on actual regulatory conditions in ${jurisdiction} for ${projectType} projects.`;
+// Re-export tool types and functions for consumers
+export type { RegulatoryAssessment } from "./tools/regulatory.js";
+export type { ContractReview } from "./tools/contract.js";
+export type { ComplianceRequirements } from "./tools/compliance.js";
+export { deriveRegulatoryAssessment, synthesizeRegulatoryAssessmentWithLLM } from "./tools/regulatory.js";
+export { deriveContractReview, synthesizeContractReviewWithLLM } from "./tools/contract.js";
+export { deriveComplianceRequirements, synthesizeComplianceRequirementsWithLLM } from "./tools/compliance.js";
 
-	try {
-		const raw = await callLLM({ prompt, maxTokens: 400 });
-		const match = raw.match(/\{[\s\S]*\}/);
-		if (!match) throw new Error("No JSON in response");
-		const parsed = JSON.parse(match[0]) as {
-			regulatoryRisk?: string;
-			keyRisks?: string[];
-			recommendations?: string[];
-		};
-		const validRisks = ["High", "Medium", "Low"];
-		if (!validRisks.includes(parsed.regulatoryRisk ?? "")) throw new Error("Invalid regulatoryRisk");
-		return {
-			regulatoryRisk: parsed.regulatoryRisk as string,
-			keyRisks: parsed.keyRisks ?? [],
-			recommendations: parsed.recommendations ?? [],
-		};
-	} catch (_err) {
-		// API unavailable — fall back to rule-based risk rating
-		return {
-			regulatoryRisk: deriveDefaultRegulatoryRisk(jurisdiction, projectType),
-			keyRisks: [
-				`${projectType} regulatory compliance in ${jurisdiction}`,
-				"Environmental permit requirements",
-				"Title and ownership verification",
-			],
-			recommendations: [
-				`Engage local counsel in ${jurisdiction}`,
-				"Complete title examination before proceeding",
-				"Obtain all required permits before operations",
-			],
-		};
-	}
-}
+// ---------------------------------------------------------------------------
+// Server template
+// ---------------------------------------------------------------------------
+
+const projectTypeSchema = z.enum(["exploration", "development", "production", "abandonment"]);
 
 const legalTemplate: ServerTemplate = {
 	name: "legal",
@@ -110,109 +66,58 @@ const legalTemplate: ServerTemplate = {
 	tools: [
 		ServerFactory.createAnalysisTool(
 			"analyze_legal_framework",
-			"Analyze legal framework and compliance requirements",
+			"Analyze regulatory and legal exposure for a jurisdiction and project type",
 			z.object({
 				jurisdiction: z.string(),
-				projectType: z.enum(["exploration", "development", "production", "abandonment"]),
+				projectType: projectTypeSchema,
 				assets: z.array(z.string()),
 				timeline: z.string().optional(),
-				outputPath: z.string().optional(),
 			}),
 			async (args) => {
-				// Ask Claude to assess real regulatory exposure for this jurisdiction and project type.
-				// Falls back to rule-based risk rating if the API is unavailable.
-				const llmResult = await synthesizeLegalAnalysisWithLLM({
+				const result = await synthesizeRegulatoryAssessmentWithLLM({
 					jurisdiction: args.jurisdiction,
 					projectType: args.projectType,
 					assets: args.assets,
 				});
-
-				const analysis = {
-					jurisdiction: args.jurisdiction,
-					project: args.projectType,
-					legal: {
-						permits: {
-							required: ["Drilling permits", "Environmental clearances", "Land use approvals", "Water usage permits"],
-							timeline: "4-6 months for standard approvals",
-							complexity: llmResult.regulatoryRisk,
-						},
-						compliance: {
-							environmental: ["NEPA review", "State environmental laws", "Local ordinances"],
-							safety: ["OSHA requirements", "DOT regulations", "State safety codes"],
-							taxation: ["Severance taxes", "Property taxes", "Income tax implications"],
-						},
-						risks: {
-							regulatory: `${llmResult.regulatoryRisk} - ${args.projectType} projects in ${args.jurisdiction}`,
-							keyRisks: llmResult.keyRisks,
-							contractual: "Standard oil & gas contract risks",
-							environmental: "Manageable with proper compliance",
-							title: args.assets.length > 1 ? "Complex - multiple assets" : "Standard",
-						},
-					},
-					recommendations: llmResult.recommendations,
-					confidence: ServerUtils.calculateConfidence(0.88, 0.85),
-				};
-
-				if (args.outputPath) {
-					await fs.writeFile(args.outputPath, JSON.stringify(analysis, null, 2));
-				}
-
-				return analysis;
+				return { ...result, confidence: ServerUtils.calculateConfidence(0.88, 0.85) };
 			},
 		),
+
 		ServerFactory.createAnalysisTool(
 			"review_contract",
-			"Review and analyze contract terms",
+			"Review and assess risk in oil & gas contract terms",
 			z.object({
 				contractType: z.enum(["lease", "JOA", "purchase", "service", "farmout"]),
 				keyTerms: z.array(z.string()),
 				parties: z.array(z.string()),
 				riskProfile: z.enum(["conservative", "moderate", "aggressive"]).default("moderate"),
-				outputPath: z.string().optional(),
 			}),
 			async (args) => {
-				const analysis = {
-					contract: {
-						type: args.contractType,
-						parties: args.parties,
-						riskProfile: args.riskProfile,
-					},
-					terms: {
-						financial: args.keyTerms.filter(
-							(t: string) =>
-								t.toLowerCase().includes("payment") ||
-								t.toLowerCase().includes("royalty") ||
-								t.toLowerCase().includes("bonus"),
-						),
-						operational: args.keyTerms.filter(
-							(t: string) => t.toLowerCase().includes("drilling") || t.toLowerCase().includes("operation"),
-						),
-						legal: args.keyTerms.filter(
-							(t: string) => t.toLowerCase().includes("liability") || t.toLowerCase().includes("indemnity"),
-						),
-					},
-					assessment: {
-						overall:
-							args.riskProfile === "conservative"
-								? "Low Risk"
-								: args.riskProfile === "moderate"
-									? "Medium Risk"
-									: "High Risk",
-						negotiability: "Standard terms with room for negotiation",
-						recommendations: [
-							"Review indemnification clauses carefully",
-							"Negotiate favorable payment terms",
-							"Ensure clear operational responsibilities",
-						],
-					},
-					confidence: ServerUtils.calculateConfidence(0.85, 0.9),
-				};
+				const result = await synthesizeContractReviewWithLLM({
+					contractType: args.contractType,
+					keyTerms: args.keyTerms,
+					parties: args.parties,
+					riskProfile: args.riskProfile,
+				});
+				return { ...result, confidence: ServerUtils.calculateConfidence(0.85, 0.9) };
+			},
+		),
 
-				if (args.outputPath) {
-					await fs.writeFile(args.outputPath, JSON.stringify(analysis, null, 2));
-				}
-
-				return analysis;
+		ServerFactory.createAnalysisTool(
+			"assess_compliance",
+			"Assess environmental, safety, and tax compliance requirements for a project",
+			z.object({
+				jurisdiction: z.string(),
+				projectType: projectTypeSchema,
+				assetCount: z.number().int().positive(),
+			}),
+			async (args) => {
+				const result = await synthesizeComplianceRequirementsWithLLM({
+					jurisdiction: args.jurisdiction,
+					projectType: args.projectType,
+					assetCount: args.assetCount,
+				});
+				return { ...result, confidence: ServerUtils.calculateConfidence(0.82, 0.88) };
 			},
 		),
 	],

--- a/servers/legal/src/tools/compliance.ts
+++ b/servers/legal/src/tools/compliance.ts
@@ -1,0 +1,104 @@
+/**
+ * O&G compliance requirements — environmental, safety, and tax obligations by jurisdiction.
+ */
+
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface ComplianceRequirements {
+	environmentalRequirements: string[];
+	safetyRequirements: string[];
+	taxObligations: string[];
+	complianceRisk: "High" | "Medium" | "Low";
+	estimatedComplianceCost: "Low (<$100K)" | "Medium ($100K–$500K)" | "High (>$500K)";
+}
+
+// Jurisdictions with higher compliance cost burden
+const HIGH_COST_JURISDICTIONS = ["california", "colorado", "new mexico"];
+
+export function deriveComplianceRequirements(
+	jurisdiction: string,
+	projectType: "exploration" | "development" | "production" | "abandonment",
+	assetCount: number,
+): ComplianceRequirements {
+	const jLower = jurisdiction.toLowerCase();
+	const isHighCost = HIGH_COST_JURISDICTIONS.some((j) => jLower.includes(j));
+
+	const complianceRisk: "High" | "Medium" | "Low" =
+		isHighCost || projectType === "exploration" ? "High"
+		: assetCount > 5 || projectType === "development" ? "Medium"
+		: "Low";
+
+	const estimatedComplianceCost: "Low (<$100K)" | "Medium ($100K–$500K)" | "High (>$500K)" =
+		complianceRisk === "High" ? "High (>$500K)"
+		: complianceRisk === "Medium" ? "Medium ($100K–$500K)"
+		: "Low (<$100K)";
+
+	const environmentalRequirements = ["NEPA review", "State environmental laws", "Local ordinances"];
+	if (isHighCost) environmentalRequirements.push("Air quality monitoring program");
+	if (projectType === "exploration") environmentalRequirements.push("Baseline environmental survey");
+
+	const safetyRequirements = ["OSHA requirements", "DOT regulations", "State safety codes"];
+	if (projectType === "development") safetyRequirements.push("Well control certification");
+
+	const taxObligations = ["Severance taxes", "Property taxes", "Income tax implications"];
+	if (!jLower.includes("texas") && !jLower.includes("oklahoma")) {
+		taxObligations.push("State-specific extraction tax");
+	}
+
+	return {
+		environmentalRequirements,
+		safetyRequirements,
+		taxObligations,
+		complianceRisk,
+		estimatedComplianceCost,
+	};
+}
+
+export async function synthesizeComplianceRequirementsWithLLM(params: {
+	jurisdiction: string;
+	projectType: "exploration" | "development" | "production" | "abandonment";
+	assetCount: number;
+}): Promise<ComplianceRequirements> {
+	const { jurisdiction, projectType, assetCount } = params;
+	const base = deriveComplianceRequirements(jurisdiction, projectType, assetCount);
+
+	const prompt = `You are Legatus Juridicus, a master oil & gas legal strategist.
+
+Assess compliance requirements for this project. Return a JSON object.
+
+PROJECT:
+Jurisdiction: ${jurisdiction}
+Type: ${projectType}
+Number of assets: ${assetCount}
+
+Return ONLY valid JSON in this exact shape:
+{
+  "complianceRisk": "High" | "Medium" | "Low",
+  "environmentalRequirements": ["<req 1>", "<req 2>"],
+  "safetyRequirements": ["<req 1>", "<req 2>"],
+  "taxObligations": ["<obligation 1>", "<obligation 2>"]
+}`;
+
+	try {
+		const raw = await callLLM({ prompt, maxTokens: 350 });
+		const match = raw.match(/\{[\s\S]*\}/);
+		if (!match) throw new Error("No JSON in response");
+		const parsed = JSON.parse(match[0]) as Partial<{
+			complianceRisk: string;
+			environmentalRequirements: string[];
+			safetyRequirements: string[];
+			taxObligations: string[];
+		}>;
+		const validRisks: string[] = ["High", "Medium", "Low"];
+		if (!validRisks.includes(parsed.complianceRisk ?? "")) throw new Error("Invalid complianceRisk");
+		return {
+			...base,
+			complianceRisk: parsed.complianceRisk as "High" | "Medium" | "Low",
+			environmentalRequirements: parsed.environmentalRequirements ?? base.environmentalRequirements,
+			safetyRequirements: parsed.safetyRequirements ?? base.safetyRequirements,
+			taxObligations: parsed.taxObligations ?? base.taxObligations,
+		};
+	} catch (_err) {
+		return base;
+	}
+}

--- a/servers/legal/src/tools/contract.ts
+++ b/servers/legal/src/tools/contract.ts
@@ -1,0 +1,102 @@
+/**
+ * Oil & gas contract review and analysis.
+ * Classifies key terms and assesses negotiation risk by contract type.
+ */
+
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface ContractReview {
+	contractType: string;
+	overallRisk: "High" | "Medium" | "Low";
+	financialTerms: string[];
+	operationalTerms: string[];
+	legalTerms: string[];
+	negotiabilityNotes: string;
+	recommendations: string[];
+}
+
+// Contract types with higher default risk exposure
+const HIGH_RISK_CONTRACT_TYPES = ["JOA", "farmout"];
+
+export function deriveContractReview(
+	contractType: "lease" | "JOA" | "purchase" | "service" | "farmout",
+	keyTerms: string[],
+	riskProfile: "conservative" | "moderate" | "aggressive",
+): ContractReview {
+	const overallRisk: "High" | "Medium" | "Low" =
+		riskProfile === "conservative" ? "Low"
+		: riskProfile === "aggressive" ? "High"
+		: HIGH_RISK_CONTRACT_TYPES.includes(contractType) ? "High"
+		: "Medium";
+
+	return {
+		contractType,
+		overallRisk,
+		financialTerms: keyTerms.filter(
+			(t) =>
+				t.toLowerCase().includes("payment") ||
+				t.toLowerCase().includes("royalty") ||
+				t.toLowerCase().includes("bonus"),
+		),
+		operationalTerms: keyTerms.filter(
+			(t) => t.toLowerCase().includes("drilling") || t.toLowerCase().includes("operation"),
+		),
+		legalTerms: keyTerms.filter(
+			(t) => t.toLowerCase().includes("liability") || t.toLowerCase().includes("indemnity"),
+		),
+		negotiabilityNotes: "Standard terms with room for negotiation",
+		recommendations: [
+			"Review indemnification clauses carefully",
+			"Negotiate favorable payment terms",
+			"Ensure clear operational responsibilities",
+		],
+	};
+}
+
+export async function synthesizeContractReviewWithLLM(params: {
+	contractType: "lease" | "JOA" | "purchase" | "service" | "farmout";
+	keyTerms: string[];
+	parties: string[];
+	riskProfile: "conservative" | "moderate" | "aggressive";
+}): Promise<ContractReview> {
+	const { contractType, keyTerms, parties, riskProfile } = params;
+	const base = deriveContractReview(contractType, keyTerms, riskProfile);
+
+	const prompt = `You are Legatus Juridicus, a master oil & gas legal strategist.
+
+Review this oil & gas contract and provide risk assessment. Return a JSON object.
+
+CONTRACT:
+Type: ${contractType}
+Parties: ${parties.join(", ")}
+Risk profile: ${riskProfile}
+Key terms: ${keyTerms.join("; ")}
+
+Return ONLY valid JSON in this exact shape:
+{
+  "overallRisk": "High" | "Medium" | "Low",
+  "negotiabilityNotes": "<one sentence on negotiability>",
+  "recommendations": ["<rec 1>", "<rec 2>", "<rec 3>"]
+}`;
+
+	try {
+		const raw = await callLLM({ prompt, maxTokens: 300 });
+		const match = raw.match(/\{[\s\S]*\}/);
+		if (!match) throw new Error("No JSON in response");
+		const parsed = JSON.parse(match[0]) as Partial<{
+			overallRisk: string;
+			negotiabilityNotes: string;
+			recommendations: string[];
+		}>;
+		const validRisks: string[] = ["High", "Medium", "Low"];
+		if (!validRisks.includes(parsed.overallRisk ?? "")) throw new Error("Invalid overallRisk");
+		return {
+			...base,
+			overallRisk: parsed.overallRisk as "High" | "Medium" | "Low",
+			negotiabilityNotes: parsed.negotiabilityNotes ?? base.negotiabilityNotes,
+			recommendations: parsed.recommendations ?? base.recommendations,
+		};
+	} catch (_err) {
+		return base;
+	}
+}

--- a/servers/legal/src/tools/regulatory.ts
+++ b/servers/legal/src/tools/regulatory.ts
@@ -1,0 +1,103 @@
+/**
+ * Regulatory risk assessment for oil & gas projects.
+ * Covers US jurisdiction-specific risk and key regulatory exposure.
+ */
+
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface RegulatoryAssessment {
+	regulatoryRisk: "High" | "Medium" | "Low";
+	keyRisks: string[];
+	recommendations: string[];
+	requiredPermits: string[];
+	approvalTimelineMonths: number;
+}
+
+// Jurisdictions with elevated regulatory burden for O&G
+const HIGH_RISK_JURISDICTIONS = ["california", "colorado", "new mexico"];
+
+export function deriveRegulatoryAssessment(
+	jurisdiction: string,
+	projectType: "exploration" | "development" | "production" | "abandonment",
+): RegulatoryAssessment {
+	const jLower = jurisdiction.toLowerCase();
+	const isHighJurisdiction = HIGH_RISK_JURISDICTIONS.some((j) => jLower.includes(j));
+
+	let regulatoryRisk: "High" | "Medium" | "Low";
+	if (projectType === "exploration" || isHighJurisdiction) regulatoryRisk = "High";
+	else if (projectType === "development") regulatoryRisk = "Medium";
+	else regulatoryRisk = "Low";
+
+	const approvalTimelineMonths = regulatoryRisk === "High" ? 12 : regulatoryRisk === "Medium" ? 6 : 3;
+
+	const requiredPermits = [
+		"Drilling/Operations Permit",
+		"Environmental Clearance",
+		"Land Use Approval",
+	];
+	if (projectType === "exploration") requiredPermits.push("Exploration License");
+	if (isHighJurisdiction) requiredPermits.push("State-Specific Regulatory Filing");
+
+	return {
+		regulatoryRisk,
+		keyRisks: [
+			`${projectType} regulatory compliance in ${jurisdiction}`,
+			"Environmental permit requirements",
+			"Title and ownership verification",
+		],
+		recommendations: [
+			`Engage local counsel in ${jurisdiction}`,
+			"Complete title examination before proceeding",
+			"Obtain all required permits before operations",
+		],
+		requiredPermits,
+		approvalTimelineMonths,
+	};
+}
+
+export async function synthesizeRegulatoryAssessmentWithLLM(params: {
+	jurisdiction: string;
+	projectType: "exploration" | "development" | "production" | "abandonment";
+	assets: string[];
+}): Promise<RegulatoryAssessment> {
+	const { jurisdiction, projectType, assets } = params;
+
+	const prompt = `You are Legatus Juridicus, a master oil & gas legal strategist.
+
+Analyze the regulatory and legal exposure for this project. Return a JSON object.
+
+PROJECT:
+Jurisdiction: ${jurisdiction}
+Project type: ${projectType}
+Assets: ${assets.join(", ")}
+
+Return ONLY valid JSON in this exact shape:
+{
+  "regulatoryRisk": "High" | "Medium" | "Low",
+  "keyRisks": ["<risk 1>", "<risk 2>", "<risk 3>"],
+  "recommendations": ["<action 1>", "<action 2>", "<action 3>"]
+}`;
+
+	try {
+		const raw = await callLLM({ prompt, maxTokens: 400 });
+		const match = raw.match(/\{[\s\S]*\}/);
+		if (!match) throw new Error("No JSON in response");
+		const parsed = JSON.parse(match[0]) as Partial<{
+			regulatoryRisk: string;
+			keyRisks: string[];
+			recommendations: string[];
+		}>;
+		const validRisks: string[] = ["High", "Medium", "Low"];
+		if (!validRisks.includes(parsed.regulatoryRisk ?? "")) throw new Error("Invalid regulatoryRisk");
+
+		const base = deriveRegulatoryAssessment(jurisdiction, projectType);
+		return {
+			...base,
+			regulatoryRisk: parsed.regulatoryRisk as "High" | "Medium" | "Low",
+			keyRisks: parsed.keyRisks ?? base.keyRisks,
+			recommendations: parsed.recommendations ?? base.recommendations,
+		};
+	} catch (_err) {
+		return deriveRegulatoryAssessment(jurisdiction, projectType);
+	}
+}

--- a/servers/legal/tests/tools.test.ts
+++ b/servers/legal/tests/tools.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Legal Server — domain logic unit tests.
+ * Tests real logic in deriveRegulatoryAssessment, deriveContractReview, deriveComplianceRequirements.
+ * No API key required.
+ */
+
+import assert from "node:assert";
+import { deriveRegulatoryAssessment } from "../src/tools/regulatory.js";
+import { deriveContractReview } from "../src/tools/contract.js";
+import { deriveComplianceRequirements } from "../src/tools/compliance.js";
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void): void {
+	try {
+		fn();
+		console.log(`  ✅ ${name}`);
+		passed++;
+	} catch (err) {
+		console.error(`  ❌ ${name}: ${err instanceof Error ? err.message : String(err)}`);
+		failed++;
+	}
+}
+
+// ── deriveRegulatoryAssessment ─────────────────────────────────────────────────
+
+console.log("\n=== RegulatoryAssessment ===\n");
+
+test("California → High risk (high-risk jurisdiction)", () => {
+	const r = deriveRegulatoryAssessment("California", "production");
+	assert.strictEqual(r.regulatoryRisk, "High");
+});
+
+test("exploration project → High risk regardless of jurisdiction", () => {
+	const r = deriveRegulatoryAssessment("Texas", "exploration");
+	assert.strictEqual(r.regulatoryRisk, "High");
+});
+
+test("Texas development → Medium risk", () => {
+	const r = deriveRegulatoryAssessment("Texas", "development");
+	assert.strictEqual(r.regulatoryRisk, "Medium");
+});
+
+test("Texas production → Low risk", () => {
+	const r = deriveRegulatoryAssessment("Texas", "production");
+	assert.strictEqual(r.regulatoryRisk, "Low");
+});
+
+test("High risk → 12 month approval timeline", () => {
+	const r = deriveRegulatoryAssessment("California", "production");
+	assert.strictEqual(r.approvalTimelineMonths, 12);
+});
+
+test("Medium risk → 6 month approval timeline", () => {
+	const r = deriveRegulatoryAssessment("Texas", "development");
+	assert.strictEqual(r.approvalTimelineMonths, 6);
+});
+
+test("Low risk → 3 month approval timeline", () => {
+	const r = deriveRegulatoryAssessment("Texas", "production");
+	assert.strictEqual(r.approvalTimelineMonths, 3);
+});
+
+test("requiredPermits is non-empty", () => {
+	const r = deriveRegulatoryAssessment("Texas", "production");
+	assert.ok(r.requiredPermits.length > 0);
+});
+
+test("exploration adds Exploration License permit", () => {
+	const r = deriveRegulatoryAssessment("Texas", "exploration");
+	assert.ok(r.requiredPermits.some((p) => p.includes("Exploration")));
+});
+
+test("California adds state-specific filing", () => {
+	const r = deriveRegulatoryAssessment("California", "production");
+	assert.ok(r.requiredPermits.some((p) => p.toLowerCase().includes("state")));
+});
+
+test("keyRisks is non-empty", () => {
+	const r = deriveRegulatoryAssessment("Texas", "production");
+	assert.ok(r.keyRisks.length > 0);
+});
+
+test("recommendations is non-empty", () => {
+	const r = deriveRegulatoryAssessment("Texas", "production");
+	assert.ok(r.recommendations.length > 0);
+});
+
+// ── deriveContractReview ────────────────────────────────────────────────────────
+
+console.log("\n=== ContractReview ===\n");
+
+test("conservative risk profile → Low overall risk", () => {
+	const r = deriveContractReview("lease", [], "conservative");
+	assert.strictEqual(r.overallRisk, "Low");
+});
+
+test("aggressive risk profile → High overall risk", () => {
+	const r = deriveContractReview("lease", [], "aggressive");
+	assert.strictEqual(r.overallRisk, "High");
+});
+
+test("JOA with moderate profile → High overall risk", () => {
+	const r = deriveContractReview("JOA", [], "moderate");
+	assert.strictEqual(r.overallRisk, "High");
+});
+
+test("farmout with moderate profile → High overall risk", () => {
+	const r = deriveContractReview("farmout", [], "moderate");
+	assert.strictEqual(r.overallRisk, "High");
+});
+
+test("service contract with moderate profile → Medium overall risk", () => {
+	const r = deriveContractReview("service", [], "moderate");
+	assert.strictEqual(r.overallRisk, "Medium");
+});
+
+test("royalty term classified as financial", () => {
+	const r = deriveContractReview("lease", ["royalty clause 20%"], "moderate");
+	assert.ok(r.financialTerms.some((t) => t.includes("royalty")));
+});
+
+test("drilling term classified as operational", () => {
+	const r = deriveContractReview("JOA", ["drilling obligations by operator"], "moderate");
+	assert.ok(r.operationalTerms.some((t) => t.includes("drilling")));
+});
+
+test("indemnity term classified as legal", () => {
+	const r = deriveContractReview("lease", ["mutual indemnity clause"], "moderate");
+	assert.ok(r.legalTerms.some((t) => t.includes("indemnity")));
+});
+
+test("recommendations is non-empty", () => {
+	const r = deriveContractReview("lease", [], "moderate");
+	assert.ok(r.recommendations.length > 0);
+});
+
+// ── deriveComplianceRequirements ────────────────────────────────────────────────
+
+console.log("\n=== ComplianceRequirements ===\n");
+
+test("California → High compliance risk", () => {
+	const r = deriveComplianceRequirements("California", "production", 3);
+	assert.strictEqual(r.complianceRisk, "High");
+});
+
+test("exploration → High compliance risk regardless of jurisdiction", () => {
+	const r = deriveComplianceRequirements("Texas", "exploration", 1);
+	assert.strictEqual(r.complianceRisk, "High");
+});
+
+test("Texas production, 1 asset → Low compliance risk", () => {
+	const r = deriveComplianceRequirements("Texas", "production", 1);
+	assert.strictEqual(r.complianceRisk, "Low");
+});
+
+test("Texas development → Medium compliance risk", () => {
+	const r = deriveComplianceRequirements("Texas", "development", 2);
+	assert.strictEqual(r.complianceRisk, "Medium");
+});
+
+test("High risk → High cost estimate", () => {
+	const r = deriveComplianceRequirements("California", "production", 1);
+	assert.ok(r.estimatedComplianceCost.includes("High"));
+});
+
+test("Low risk → Low cost estimate", () => {
+	const r = deriveComplianceRequirements("Texas", "production", 1);
+	assert.ok(r.estimatedComplianceCost.includes("Low"));
+});
+
+test("environmentalRequirements includes NEPA review", () => {
+	const r = deriveComplianceRequirements("Texas", "production", 1);
+	assert.ok(r.environmentalRequirements.some((req) => req.includes("NEPA")));
+});
+
+test("safetyRequirements includes OSHA", () => {
+	const r = deriveComplianceRequirements("Texas", "production", 1);
+	assert.ok(r.safetyRequirements.some((req) => req.includes("OSHA")));
+});
+
+test("taxObligations includes severance taxes", () => {
+	const r = deriveComplianceRequirements("Texas", "production", 1);
+	assert.ok(r.taxObligations.some((t) => t.toLowerCase().includes("severance")));
+});
+
+test("California adds air quality monitoring", () => {
+	const r = deriveComplianceRequirements("California", "production", 1);
+	assert.ok(r.environmentalRequirements.some((req) => req.toLowerCase().includes("air quality")));
+});
+
+test("exploration adds baseline environmental survey", () => {
+	const r = deriveComplianceRequirements("Texas", "exploration", 1);
+	assert.ok(r.environmentalRequirements.some((req) => req.toLowerCase().includes("baseline")));
+});
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Closes #370 — full legal / legal-analyst pair, Steps A + B.

### Step A — Tier 1 server modularization (`servers/legal/`)
- Split monolithic `src/index.ts` into 3 focused domain modules:
  - `src/tools/regulatory.ts` — jurisdiction risk (`High/Medium/Low`), permit lists, approval timelines; `HIGH_RISK_JURISDICTIONS` (CA, CO, NM)
  - `src/tools/contract.ts` — JOA/lease/farmout risk classification, term bucketing (financial/operational/legal)
  - `src/tools/compliance.ts` — environmental (NEPA, air quality), safety (OSHA, DOT), tax obligations by jurisdiction
- Added **third MCP tool**: `assess_compliance` backed by `compliance.ts`
- `tests/tools.test.ts` — 32 unit tests covering all domain logic (no API key required)
- Backward-compat exports preserved; existing tests unchanged

### Step B — Tier 2 agent implementation (`agents/legal-analyst/`)
- `src/agent/legal-client.ts` — MCP HTTP client with 30s timeout, retryable/permanent error classification (Arcade #28 Timeout Boundary, #39 Recovery Guide, #40 Error Classification)
- `src/agent/index.ts` — `legalAnalystManifest` (Legatus Juridicus, 3 tools, port 3006), `legalAnalystConfig`, `runLegalAnalystTask()` Layer 2 LLM execution loop with Permission Gate (Arcade #46), exponential-backoff retry
- `tests/mcp-client.test.ts` — 12 tests (client export, URL/transport config, unreachable server error, HITL challenge shape, anti-stub callLLM path)
- `tests/agent.test.ts` — 41 contract tests (manifest validation, progressive discovery, model routing, HITL policy, evals, health endpoint, invalid manifest rejection)

## Test plan
- [x] `servers/legal/tests/tools.test.ts` — 32 passed, 0 failed
- [x] `agents/legal-analyst/tests/mcp-client.test.ts` — 12 passed, 0 failed
- [x] `agents/legal-analyst/tests/agent.test.ts` — 41 passed, 0 failed
- [x] `npx tsc --noEmit` clean for `@shaleyeah/legal-analyst`

🤖 Generated with [Claude Code](https://claude.com/claude-code)