### PR TITLE
feat(qa-server): Tier 1 server split into focused domain modules (#411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **qa-server Tier 1 split** (#411) — Modularized `servers/qa-server/src/index.ts` into 2 focused domain modules.
+  - `validation.ts` — `QAValidationResult`, `deriveDefaultQAResult`, `synthesizeQAValidationWithLLM`
+  - `reporting.ts` — `QAReport`, `deriveQualityReport` (extracted deterministic fallback from handler)
+  - 23 new domain logic tests in `tests/tools.test.ts`; all 2 existing server tests still pass
+
 - **title / title-analyst pair — Steps A + B** (#372) — Full Tier 1 server modularization and Tier 2 agent implementation for oil & gas title analysis.
   - `servers/title/src/tools/` — 4 focused modules (ownership, lease-analysis, burden-check, chain-of-title) with LLM synthesis + deterministic fallbacks; `tests/tools.test.ts` (22 tests)
   - `agents/title-analyst/src/agent/` — manifest (4 tools, port 3010), runtime config, `runTitleAnalystTask()` Layer 2 loop, title MCP HTTP client; `tests/mcp-client.test.ts` (13) + `tests/agent.test.ts` (31)

--- a/servers/qa-server/CHANGELOG.md
+++ b/servers/qa-server/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-06-10
+
+### Added
+- Split monolithic `src/index.ts` into 2 focused domain modules in `src/tools/` (#411)
+  - `validation.ts` — `QAValidationResult`, `deriveDefaultQAResult`, `synthesizeQAValidationWithLLM`
+  - `reporting.ts` — `QAReport`, `deriveQualityReport` (extracted from `generate_quality_report` handler)
+- Created `tests/tools.test.ts` with 23 domain logic tests (no API key required)
+- `src/index.ts` is now a thin facade — preserved all backward-compat exports for existing tests
+- Clarified doc intent: QA server validates O&G analysis outputs (peer review of deal analysis), not runtime software monitoring
+
 ## [0.1.0] — 2026-06-04
 
 ### Added

--- a/servers/qa-server/src/index.ts
+++ b/servers/qa-server/src/index.ts
@@ -1,88 +1,33 @@
 #!/usr/bin/env node
-
 /**
- * Test MCP Server - DRY Refactored
- * Testius Validatus - Master Quality Engineer
+ * QA MCP Server — Testius Validatus, Master Quality Engineer.
+ *
+ * Validates O&G analysis outputs (economic models, geological assessments,
+ * compliance claims) before they reach the investment chair. This is peer
+ * review of deal analysis, not software monitoring.
+ *
+ * Thin facade — all domain logic lives in src/tools/.
  */
 
 import fs from "node:fs/promises";
-import { callLLM, type MCPServer, runMCPServer, ServerFactory, type ServerTemplate, ServerUtils } from "@shaleyeah/sdk";
+import { type MCPServer, runMCPServer, ServerFactory, type ServerTemplate, ServerUtils } from "@shaleyeah/sdk";
 import { z } from "zod";
 
+import { deriveDefaultQAResult, synthesizeQAValidationWithLLM } from "./tools/validation.js";
+import { deriveQualityReport } from "./tools/reporting.js";
+
 // ---------------------------------------------------------------------------
-// Exported helpers (used by tests)
+// Backward-compat exports — existing tests import these from ../src/index.js
 // ---------------------------------------------------------------------------
 
-export interface QAValidationResult {
-	overallStatus: "PASS" | "FAIL" | "WARNING";
-	issues: string[];
-	recommendation: string;
-}
+export { deriveDefaultQAResult, synthesizeQAValidationWithLLM };
+export type { QAValidationResult } from "./tools/validation.js";
+export { deriveQualityReport };
+export type { QAReport } from "./tools/reporting.js";
 
-/**
- * Rule-based QA validation — fallback when the API is unavailable.
- * Output varies with targets and criteria so tests can verify determinism.
- */
-export function deriveDefaultQAResult(targets: string[], accuracyThreshold: number): QAValidationResult {
-	// Stricter accuracy threshold → higher chance of flagging issues
-	const isTight = accuracyThreshold > 0.97;
-	const hasMultipleTargets = targets.length > 3;
-
-	return {
-		overallStatus: isTight ? "WARNING" : "PASS",
-		issues: isTight ? [`Accuracy threshold of ${accuracyThreshold * 100}% is aggressive — monitor closely`] : [],
-		recommendation: hasMultipleTargets
-			? `Validate all ${targets.length} targets individually before sign-off`
-			: "Standard QA process is sufficient for this scope",
-	};
-}
-
-/**
- * Ask Claude (Testius Validatus) to review the QA targets and flag inconsistencies.
- * Falls back to deriveDefaultQAResult() if the API is unavailable.
- */
-export async function synthesizeQAValidationWithLLM(params: {
-	testSuite: string;
-	targets: string[];
-	accuracyThreshold: number;
-	complianceStandards: string[];
-}): Promise<QAValidationResult> {
-	const { testSuite, targets, accuracyThreshold, complianceStandards } = params;
-
-	const prompt = `You are Testius Validatus, a master quality assurance engineer for oil & gas analysis systems.
-
-Review the following QA test configuration and identify any potential issues or risks. Return a JSON object.
-
-TEST SUITE: ${testSuite}
-TARGETS: ${targets.join(", ")}
-ACCURACY THRESHOLD: ${accuracyThreshold * 100}%
-COMPLIANCE STANDARDS: ${complianceStandards.length > 0 ? complianceStandards.join(", ") : "None specified"}
-
-Return ONLY valid JSON in this exact shape:
-{
-  "overallStatus": "PASS" | "FAIL" | "WARNING",
-  "issues": ["<issue 1 if any>"],
-  "recommendation": "<one sentence QA recommendation>"
-}
-
-Flag WARNING if thresholds seem unrealistic or targets are ambiguous. Flag FAIL only for clear compliance gaps.`;
-
-	try {
-		const raw = await callLLM({ prompt, maxTokens: 300 });
-		const match = raw.match(/\{[\s\S]*\}/);
-		if (!match) throw new Error("No JSON in response");
-		const parsed = JSON.parse(match[0]) as Partial<QAValidationResult>;
-		const validStatuses = ["PASS", "FAIL", "WARNING"];
-		if (!validStatuses.includes(parsed.overallStatus ?? "")) throw new Error("Invalid overallStatus");
-		return {
-			overallStatus: parsed.overallStatus as "PASS" | "FAIL" | "WARNING",
-			issues: parsed.issues ?? [],
-			recommendation: parsed.recommendation ?? "",
-		};
-	} catch (_err) {
-		return deriveDefaultQAResult(targets, accuracyThreshold);
-	}
-}
+// ---------------------------------------------------------------------------
+// Server template
+// ---------------------------------------------------------------------------
 
 const testTemplate: ServerTemplate = {
 	name: "test",
@@ -116,8 +61,6 @@ const testTemplate: ServerTemplate = {
 				outputPath: z.string().optional(),
 			}),
 			async (args) => {
-				// Ask Claude to validate the QA configuration and flag inconsistencies.
-				// Falls back to rule-based validation if API is unavailable.
 				const validation = await synthesizeQAValidationWithLLM({
 					testSuite: args.testSuite,
 					targets: args.targets,
@@ -196,61 +139,14 @@ const testTemplate: ServerTemplate = {
 				outputPath: z.string().optional(),
 			}),
 			async (args) => {
-				// Metrics requiring live telemetry (Prometheus, Datadog, etc.) are marked N/A.
-				// This server provides LLM-based QA validation, not runtime monitoring.
-				const requestedMetrics = args.metrics;
-				const analysis = {
-					report: {
-						type: args.reportType,
-						period: args.period,
-						generated: new Date().toISOString(),
-					},
-					dataSource: "llm-validation",
-					metrics: {
-						accuracy: requestedMetrics.includes("accuracy")
-							? {
-									current: "N/A — requires live telemetry",
-									target: "N/A",
-									trend: "N/A",
-								}
-							: undefined,
-						performance: requestedMetrics.includes("performance")
-							? {
-									// p50 latency and uptime require a running service to measure
-									avgResponseTime: "N/A",
-									uptime: "N/A",
-									trend: "N/A",
-								}
-							: undefined,
-						reliability: requestedMetrics.includes("reliability")
-							? {
-									// Error rate and MTBF require failure tracking infrastructure
-									errorRate: "N/A",
-									mtbf: "N/A",
-									trend: "N/A",
-								}
-							: undefined,
-					},
-					compliance: {
-						// Compliance status is assessed by LLM against declared standards, not a live audit
-						status: "LLM-assessed — verify with formal audit",
-						lastAudit: "N/A",
-						nextReview: "N/A",
-						gaps: [],
-					},
-					recommendations: [
-						"Connect to live telemetry (Prometheus/Datadog) for runtime metrics",
-						"Schedule formal compliance audit to replace LLM assessment",
-						"Continue LLM-based QA validation for configuration and threshold review",
-					],
-					confidence: ServerUtils.calculateConfidence(0.94, 0.9),
-				};
+				const report = deriveQualityReport(args.reportType, args.period, args.metrics);
+				const result = { ...report, confidence: ServerUtils.calculateConfidence(0.94, 0.9) };
 
 				if (args.outputPath) {
-					await fs.writeFile(args.outputPath, JSON.stringify(analysis, null, 2));
+					await fs.writeFile(args.outputPath, JSON.stringify(result, null, 2));
 				}
 
-				return analysis;
+				return result;
 			},
 		),
 	],

--- a/servers/qa-server/src/tools/reporting.ts
+++ b/servers/qa-server/src/tools/reporting.ts
@@ -1,0 +1,62 @@
+/**
+ * QA report generation — deterministic report structure.
+ *
+ * Metrics that require live telemetry (Prometheus, Datadog, etc.) are marked N/A.
+ * This server provides LLM-based QA validation, not runtime monitoring. The N/A
+ * values are intentional — they signal to operators that a live telemetry integration
+ * is needed for those fields (#412).
+ */
+
+export interface QAReport {
+	report: { type: string; period: string; generated: string };
+	dataSource: string;
+	metrics: {
+		accuracy?: { current: string; target: string; trend: string };
+		performance?: { avgResponseTime: string; uptime: string; trend: string };
+		reliability?: { errorRate: string; mtbf: string; trend: string };
+	};
+	compliance: { status: string; lastAudit: string; nextReview: string; gaps: string[] };
+	recommendations: string[];
+}
+
+/**
+ * Derive a quality report structure for the requested metrics and period.
+ * All live-telemetry fields return "N/A" intentionally — they require
+ * Prometheus/Datadog integration to populate.
+ */
+export function deriveQualityReport(
+	reportType: string,
+	period: string,
+	requestedMetrics: string[],
+): QAReport {
+	return {
+		report: {
+			type: reportType,
+			period,
+			generated: new Date().toISOString(),
+		},
+		dataSource: "llm-validation",
+		metrics: {
+			accuracy: requestedMetrics.includes("accuracy")
+				? { current: "N/A — requires live telemetry", target: "N/A", trend: "N/A" }
+				: undefined,
+			performance: requestedMetrics.includes("performance")
+				? { avgResponseTime: "N/A", uptime: "N/A", trend: "N/A" }
+				: undefined,
+			reliability: requestedMetrics.includes("reliability")
+				? { errorRate: "N/A", mtbf: "N/A", trend: "N/A" }
+				: undefined,
+		},
+		compliance: {
+			status: "LLM-assessed — verify with formal audit",
+			lastAudit: "N/A",
+			nextReview: "N/A",
+			gaps: [],
+		},
+		recommendations: [
+			"Connect to live telemetry (Prometheus/Datadog) for runtime metrics",
+			"Schedule formal compliance audit to replace LLM assessment",
+			"Continue LLM-based QA validation for configuration and threshold review",
+		],
+	};
+}

--- a/servers/qa-server/src/tools/validation.ts
+++ b/servers/qa-server/src/tools/validation.ts
@@ -1,0 +1,81 @@
+/**
+ * QA validation domain logic — LLM synthesis + deterministic fallback.
+ *
+ * These functions provide the core quality assessment logic for the qa-server.
+ * They validate O&G analysis outputs (economic models, geological assessments)
+ * before those outputs reach the investment chair — peer review of deal analysis,
+ * not software monitoring.
+ */
+
+import { callLLM } from "@shaleyeah/sdk";
+
+export interface QAValidationResult {
+	overallStatus: "PASS" | "FAIL" | "WARNING";
+	issues: string[];
+	recommendation: string;
+}
+
+/**
+ * Rule-based QA validation — fallback when the API is unavailable.
+ * Output varies with targets and criteria so tests can verify determinism.
+ */
+export function deriveDefaultQAResult(targets: string[], accuracyThreshold: number): QAValidationResult {
+	// Stricter accuracy threshold → higher chance of flagging issues
+	const isTight = accuracyThreshold > 0.97;
+	const hasMultipleTargets = targets.length > 3;
+
+	return {
+		overallStatus: isTight ? "WARNING" : "PASS",
+		issues: isTight ? [`Accuracy threshold of ${accuracyThreshold * 100}% is aggressive — monitor closely`] : [],
+		recommendation: hasMultipleTargets
+			? `Validate all ${targets.length} targets individually before sign-off`
+			: "Standard QA process is sufficient for this scope",
+	};
+}
+
+/**
+ * Ask Claude (Testius Validatus) to review the QA targets and flag inconsistencies.
+ * Falls back to deriveDefaultQAResult() if the API is unavailable.
+ */
+export async function synthesizeQAValidationWithLLM(params: {
+	testSuite: string;
+	targets: string[];
+	accuracyThreshold: number;
+	complianceStandards: string[];
+}): Promise<QAValidationResult> {
+	const { testSuite, targets, accuracyThreshold, complianceStandards } = params;
+
+	const prompt = `You are Testius Validatus, a master quality assurance engineer for oil & gas analysis systems.
+
+Review the following QA test configuration and identify any potential issues or risks. Return a JSON object.
+
+TEST SUITE: ${testSuite}
+TARGETS: ${targets.join(", ")}
+ACCURACY THRESHOLD: ${accuracyThreshold * 100}%
+COMPLIANCE STANDARDS: ${complianceStandards.length > 0 ? complianceStandards.join(", ") : "None specified"}
+
+Return ONLY valid JSON in this exact shape:
+{
+  "overallStatus": "PASS" | "FAIL" | "WARNING",
+  "issues": ["<issue 1 if any>"],
+  "recommendation": "<one sentence QA recommendation>"
+}
+
+Flag WARNING if thresholds seem unrealistic or targets are ambiguous. Flag FAIL only for clear compliance gaps.`;
+
+	try {
+		const raw = await callLLM({ prompt, maxTokens: 300 });
+		const match = raw.match(/\{[\s\S]*\}/);
+		if (!match) throw new Error("No JSON in response");
+		const parsed = JSON.parse(match[0]) as Partial<QAValidationResult>;
+		const validStatuses = ["PASS", "FAIL", "WARNING"];
+		if (!validStatuses.includes(parsed.overallStatus ?? "")) throw new Error("Invalid overallStatus");
+		return {
+			overallStatus: parsed.overallStatus as "PASS" | "FAIL" | "WARNING",
+			issues: parsed.issues ?? [],
+			recommendation: parsed.recommendation ?? "",
+		};
+	} catch (_err) {
+		return deriveDefaultQAResult(targets, accuracyThreshold);
+	}
+}

--- a/servers/qa-server/tests/tools.test.ts
+++ b/servers/qa-server/tests/tools.test.ts
@@ -1,0 +1,156 @@
+/**
+ * QA Server — domain logic unit tests.
+ * Tests deriveDefaultQAResult and deriveQualityReport.
+ * No API key required.
+ */
+
+import assert from "node:assert";
+import { deriveDefaultQAResult } from "../src/tools/validation.js";
+import { deriveQualityReport } from "../src/tools/reporting.js";
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => void): void {
+	try {
+		fn();
+		console.log(`  ✅ ${name}`);
+		passed++;
+	} catch (err) {
+		console.error(`  ❌ ${name}: ${err instanceof Error ? err.message : String(err)}`);
+		failed++;
+	}
+}
+
+// ── deriveDefaultQAResult ─────────────────────────────────────────────────────
+
+console.log("\n=== QAValidationResult ===\n");
+
+test("standard threshold (0.95) → PASS status", () => {
+	const r = deriveDefaultQAResult(["geowiz"], 0.95);
+	assert.strictEqual(r.overallStatus, "PASS");
+});
+
+test("tight threshold (>0.97) → WARNING status", () => {
+	const r = deriveDefaultQAResult(["geowiz"], 0.99);
+	assert.strictEqual(r.overallStatus, "WARNING");
+});
+
+test("tight threshold at exactly 0.97 → PASS (boundary)", () => {
+	const r = deriveDefaultQAResult(["geowiz"], 0.97);
+	assert.strictEqual(r.overallStatus, "PASS");
+});
+
+test("tight threshold → issues array is non-empty", () => {
+	const r = deriveDefaultQAResult(["geowiz", "econobot"], 0.98);
+	assert.ok(r.issues.length > 0, "Tight threshold must produce at least one issue");
+});
+
+test("standard threshold → issues array is empty", () => {
+	const r = deriveDefaultQAResult(["geowiz"], 0.95);
+	assert.strictEqual(r.issues.length, 0);
+});
+
+test("tight threshold → issue message references the threshold value", () => {
+	const r = deriveDefaultQAResult(["geowiz"], 0.99);
+	assert.ok(r.issues[0].includes("99"), `Expected '99' in issue, got: ${r.issues[0]}`);
+});
+
+test("≤3 targets → standard recommendation", () => {
+	const r = deriveDefaultQAResult(["geowiz", "econobot"], 0.95);
+	assert.ok(r.recommendation.includes("Standard"), `Expected 'Standard' in recommendation`);
+});
+
+test(">3 targets → per-target recommendation", () => {
+	const r = deriveDefaultQAResult(["geowiz", "econobot", "decision", "legal"], 0.95);
+	assert.ok(r.recommendation.includes("4"), `Expected target count in recommendation`);
+});
+
+test("recommendation is a non-empty string", () => {
+	const r = deriveDefaultQAResult(["geowiz"], 0.95);
+	assert.ok(typeof r.recommendation === "string" && r.recommendation.length > 0);
+});
+
+test("no hardcoded legacy constants in output", () => {
+	const r = deriveDefaultQAResult(["geowiz", "econobot"], 0.95);
+	const s = JSON.stringify(r);
+	assert.ok(!s.includes("145ms"), "Must not contain legacy '145ms'");
+	assert.ok(!s.includes("420 requests"), "Must not contain legacy '420 requests'");
+	assert.ok(!s.includes('"score": 95'), "Must not contain legacy fixed score");
+});
+
+test("different inputs → different outputs", () => {
+	const a = deriveDefaultQAResult(["geowiz"], 0.95);
+	const b = deriveDefaultQAResult(["geowiz", "econobot", "decision", "legal", "market"], 0.99);
+	assert.ok(a.overallStatus !== b.overallStatus || a.recommendation !== b.recommendation);
+});
+
+// ── deriveQualityReport ───────────────────────────────────────────────────────
+
+console.log("\n=== QAReport ===\n");
+
+test("report type is preserved", () => {
+	const r = deriveQualityReport("summary", "current", ["accuracy"]);
+	assert.strictEqual(r.report.type, "summary");
+});
+
+test("period is preserved", () => {
+	const r = deriveQualityReport("detailed", "Q2-2026", ["accuracy"]);
+	assert.strictEqual(r.report.period, "Q2-2026");
+});
+
+test("generated is an ISO timestamp string", () => {
+	const r = deriveQualityReport("summary", "current", ["accuracy"]);
+	assert.ok(typeof r.report.generated === "string" && r.report.generated.includes("T"));
+});
+
+test("dataSource is 'llm-validation'", () => {
+	const r = deriveQualityReport("summary", "current", ["accuracy"]);
+	assert.strictEqual(r.dataSource, "llm-validation");
+});
+
+test("accuracy metric present when requested", () => {
+	const r = deriveQualityReport("summary", "current", ["accuracy"]);
+	assert.ok(r.metrics.accuracy !== undefined);
+});
+
+test("performance metric present when requested", () => {
+	const r = deriveQualityReport("summary", "current", ["performance"]);
+	assert.ok(r.metrics.performance !== undefined);
+});
+
+test("reliability metric present when requested", () => {
+	const r = deriveQualityReport("summary", "current", ["reliability"]);
+	assert.ok(r.metrics.reliability !== undefined);
+});
+
+test("metric absent when not requested", () => {
+	const r = deriveQualityReport("summary", "current", ["accuracy"]);
+	assert.strictEqual(r.metrics.performance, undefined);
+	assert.strictEqual(r.metrics.reliability, undefined);
+});
+
+test("accuracy metric values are N/A (no live telemetry)", () => {
+	const r = deriveQualityReport("summary", "current", ["accuracy"]);
+	assert.ok(r.metrics.accuracy!.current.includes("N/A"));
+});
+
+test("compliance status references LLM assessment", () => {
+	const r = deriveQualityReport("summary", "current", []);
+	assert.ok(r.compliance.status.includes("LLM-assessed"));
+});
+
+test("compliance gaps is an array", () => {
+	const r = deriveQualityReport("summary", "current", []);
+	assert.ok(Array.isArray(r.compliance.gaps));
+});
+
+test("recommendations is a non-empty array", () => {
+	const r = deriveQualityReport("summary", "current", ["accuracy"]);
+	assert.ok(r.recommendations.length > 0);
+});
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary

- Split `servers/qa-server/src/index.ts` into 2 focused domain modules in `src/tools/`:
  - `validation.ts` — `QAValidationResult`, `deriveDefaultQAResult`, `synthesizeQAValidationWithLLM`
  - `reporting.ts` — `QAReport`, `deriveQualityReport` (extracted deterministic logic from the `generate_quality_report` handler)
- `src/index.ts` is now a thin facade — all backward-compat exports preserved, no existing tests broken
- 23 new domain logic tests in `tests/tools.test.ts` (no API key required)

**Doc clarity note:** The QA server header now explicitly states this is O&G analysis peer review (validating economic models and geological assessments before they reach the investment chair), not runtime software monitoring. The `N/A` telemetry values are intentional — they signal that Prometheus/Datadog integration is needed (#412).

## Test plan

- [ ] `cd servers/qa-server && npx tsx tests/tools.test.ts` — 23 passed
- [ ] `cd servers/qa-server && npx tsx tests/server.test.ts` — 2 passed (backward compat)
- [ ] Step B (quality-assurance agent) already complete — MCP client + runTask tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)