### PR TITLE
fix(#403): audit scope failures in LocalAgentRuntime.execute()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`LocalAgentRuntime.execute()` now audits scope failures** (#403) — Scope rejections were already returned as `status: "failed"` but bypassed the audit log. The missing-scopes error is now written to the audit trail before returning, consistent with HITL and eval failures. Adds 3 tests to `agents/geologist/tests/agent.test.ts` verifying audit entry presence, status, and error message on scope rejection.
+
 ### Added
 
 - **research / research-analyst pair — Steps A + B + C** (#369) — Tier 1 server modularization and full Tier 2 agent for O&G market intelligence.

--- a/agents/geologist/tests/agent.test.ts
+++ b/agents/geologist/tests/agent.test.ts
@@ -266,6 +266,32 @@ console.log("\n🔒 Testing scope enforcement (issue #403)...");
 	await runtime.shutdown();
 }
 
+{
+	// Scope failures must be audited — the missing-scopes message must appear in the audit log.
+	const auditEntries: unknown[] = [];
+	const { LocalAgentRuntime } = await import("@shaleyeah/sdk");
+	const auditRuntime = new LocalAgentRuntime({
+		manifest: geologistManifest,
+		config: geologistConfig,
+		handlers: Object.fromEntries(geologistManifest.tools.map((t) => [t.name, async () => ({ ok: true })])),
+		auditLogger: (entry) => auditEntries.push(entry),
+	});
+	await auditRuntime.initialize();
+
+	await auditRuntime.execute({
+		toolName: "geologist.assess_quality",
+		args: { filePath: "test.las", dataType: "las" },
+		grantedScopes: [],
+	});
+
+	assert(auditEntries.length === 1, "Scope failure produces an audit entry");
+	const entry = auditEntries[0] as { status: string; error?: string } | undefined;
+	assert(entry?.status === "failed", "Audit entry status is failed");
+	assert(entry?.error?.includes("Missing required scopes") ?? false, "Audit entry error names missing scopes");
+
+	await auditRuntime.shutdown();
+}
+
 console.log("\n🧱 Testing blocking eval halt (issue #404)...");
 {
 	// A handler that returns undefined triggers the schema blocking eval.

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`LocalAgentRuntime.execute()` audits scope failures** (#403) — Scope rejections now call `this.audit()` before returning the `failed` result, so missing-scope events appear in the audit trail alongside HITL and eval failures.
+
 ### Added
 - **HTTP transport mode for `MCPServer`** (#363) — `MCPServer` now selects `StreamableHTTPServerTransport` when the `PORT` env var is set at construction time, and falls back to `StdioServerTransport` otherwise. All 14 inheriting servers gain HTTP capability without any per-server code change. New public helpers: `isHttpMode()` and `httpPort()`. `initialize()` starts the Node.js HTTP server and binds on the configured port; `stop()` closes it cleanly.
 

--- a/sdk/src/runtime.ts
+++ b/sdk/src/runtime.ts
@@ -148,7 +148,10 @@ export class LocalAgentRuntime implements AgentRuntime {
 		if (request.grantedScopes) {
 			const missing = tool.requiredScopes.filter((s) => !request.grantedScopes!.includes(s));
 			if (missing.length > 0) {
-				return this.failed(tool.name, `Missing required scopes: ${missing.join(", ")}`, tool.modelRequirement);
+				const scopeError = `Missing required scopes: ${missing.join(", ")}`;
+				const result = this.failed(tool.name, scopeError, tool.modelRequirement);
+				this.audit(tool.name, request.args, result, Date.now() - startMs, scopeError);
+				return result;
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Scope failures in `LocalAgentRuntime.execute()` now call `this.audit()` before returning, so missing-scope rejections appear in the audit trail alongside HITL and blocking-eval failures
- Adds 3 tests to `agents/geologist/tests/agent.test.ts` verifying an audit entry is written with `status: "failed"` and the correct missing-scopes message
- `grantedScopes?: string[]` on `AgentExecutionRequest` and the scope check itself were already in place; this closes the audit gap

## Test plan

- [x] `npx tsx agents/geologist/tests/agent.test.ts` — 44 passed, 0 failed (up from 41)
- [x] New tests: scope failure produces audit entry ✅, audit entry status is failed ✅, audit entry error names missing scopes ✅
- [x] Existing scope tests still pass: missing scope blocks tool, correct scopes accepted
- [x] `pnpm turbo build` — 31/31 ✅
- [x] `pnpm turbo lint` — 25/25 ✅
- [x] `pnpm turbo test` — 26/26 ✅

closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)