### PR TITLE
fix(#423): halt economist executeLoop on permanent failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`executeLoop` halts on permanent failures in economist agent** (#423) — `else` branch in `runEconomistTask`'s `executeLoop` previously logged a hint string and continued when `execResult.retryable === false`. Now returns immediately, matching the geologist Level 2 reference. Adds 2 contract tests verifying blocking eval halts the loop.
+
 - **`executeLoop` now halts on permanent failures** (#404) — `runGeologistTask`'s `executeLoop` previously pushed non-retryable errors (blocking evals, scope rejections) into the conversation history and continued the task loop. Now returns immediately when `execResult.retryable === false`, so safety gates actually stop execution. Adds 7 tests to `agents/geologist/tests/agent.test.ts` covering `redactSecrets` blocking on `sk-` output and advisory schema completing with a warn.
 
 - **`LocalAgentRuntime.execute()` now audits scope failures** (#403) — Scope rejections were already returned as `status: "failed"` but bypassed the audit log. The missing-scopes error is now written to the audit trail before returning, consistent with HITL and eval failures. Adds 3 tests to `agents/geologist/tests/agent.test.ts` verifying audit entry presence, status, and error message on scope rejection.

--- a/agents/economist/CHANGELOG.md
+++ b/agents/economist/CHANGELOG.md
@@ -12,3 +12,6 @@
 ### Changed
 - `modelRouting` dev defaults wired to real Anthropic model IDs (`claude-sonnet-4-6` for standard-analysis, `claude-opus-4-8` for deep-reasoning, `claude-haiku-4-5-20251001` for small-fast / local-private) — replaces `configured-by-operator` placeholders (#364)
 - `executeLoop` resolves `reasoningModel` from `config.modelRouting["standard-analysis"]` and passes it to all `callLLM()` calls so BYOE overrides flow through (#364)
+
+### Fixed
+- **`executeLoop` halts on permanent failures** (#423) — The `else` branch previously appended a hint string and continued the loop when `execResult.retryable === false` (blocking evals, scope rejections, security gates). Now returns immediately with the error string, matching the geologist Level 2 reference. Adds 2 tests to `tests/agent.test.ts` covering blocking schema eval halt + error string assertion.

--- a/agents/economist/src/agent/index.ts
+++ b/agents/economist/src/agent/index.ts
@@ -443,8 +443,16 @@ If you cannot complete the task with the available tools, respond with {"action"
 				history.push({ role: "tool", content: `Error after approval for ${parsed.tool}: ${err}` });
 			}
 		} else {
-			const hint = execResult.retryable ? " (retryable — server may be temporarily unavailable)" : " (permanent)";
-			history.push({ role: "tool", content: `Error calling ${parsed.tool}: ${execResult.error}${hint}` });
+			// Permanent failure (blocking eval, scope rejection, unretryable error) — safety gate,
+			// do not continue the loop. The LLM cannot recover from a security or governance halt.
+			if (!execResult.retryable) {
+				return execResult.error ?? `Permanent failure calling ${parsed.tool}`;
+			}
+			// Transient failure — push to history so the LLM can reformulate and retry.
+			history.push({
+				role: "tool",
+				content: `Error calling ${parsed.tool}: ${execResult.error} (retryable — server may be temporarily unavailable)`,
+			});
 		}
 	}
 

--- a/agents/economist/tests/agent.test.ts
+++ b/agents/economist/tests/agent.test.ts
@@ -5,12 +5,13 @@
  * and that the economist manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, LocalAgentRuntime } from "@shaleyeah/sdk";
+import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
 import {
 	createEconomistEndpoint,
 	createEconomistRuntime,
 	economistConfig,
 	economistManifest,
+	runEconomistTask,
 } from "../src/agent/index.js";
 
 let passed = 0;
@@ -180,6 +181,51 @@ console.log("\n🏥 Testing health endpoint and standalone boot...");
 
 	const toolSchema = await endpoint.discoveryToolSchema("economist.calculate_dcf");
 	assert(toolSchema !== null, "Endpoint exposes tool schemas by name");
+}
+
+console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #423)...");
+{
+	// A blocking schema eval sets retryable: false on execute(). executeLoop must
+	// immediately return the error — do not continue to the next LLM step.
+	// Without the fix, the else branch logs the hint and calls the LLM a second time.
+	const blockingConfig: typeof economistConfig = {
+		...economistConfig,
+		evals: {
+			...economistConfig.evals,
+			checks: { ...economistConfig.evals.checks, schema: "blocking" },
+		},
+	};
+	const blockingRuntime = new LocalAgentRuntime({
+		manifest: economistManifest,
+		config: blockingConfig,
+		// Handler returns undefined — triggers blocking schema eval failure on execute()
+		handlers: Object.fromEntries(economistManifest.tools.map((t) => [t.name, async () => undefined])),
+	});
+	await blockingRuntime.initialize();
+
+	const llmCallCount: number[] = [];
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		llmCallCount.push(1);
+		if (llmCallCount.length === 1) {
+			return JSON.stringify({
+				action: "tool",
+				tool: "economist.calculate_dcf",
+				args: { cashFlows: [-100, 60, 70], discountRate: 0.1 },
+			});
+		}
+		return JSON.stringify({ action: "done", answer: "should not reach here" });
+	};
+
+	const result = await runEconomistTask("calculate DCF", {
+		config: blockingConfig,
+		callLLM: mockLLM,
+		runtime: blockingRuntime,
+	});
+
+	assert(llmCallCount.length === 1, "executeLoop halts after permanent failure — LLM not called a second time");
+	assert(typeof result === "string" && result.length > 0, "Permanent failure returns non-empty error string");
+
+	await blockingRuntime.shutdown();
 }
 
 console.log("\n🛑 Testing invalid manifest fails early...");


### PR DESCRIPTION
## Summary

- `executeLoop` in `runEconomistTask` previously logged a hint string and **continued the loop** when `execResult.retryable === false` (blocking evals, scope rejections, security gates)
- Now returns immediately with the error string, matching the geologist Level 2 reference pattern from #404
- Adds 2 contract tests: blocking schema eval halts the loop (LLM called once, not twice) + returned value is non-empty error string

## Test plan

- [x] New test: blocking schema eval (`retryable: false`) — assert `llmCallCount.length === 1` (loop halted) and result is non-empty string
- [x] Existing `agent.test.ts` — 44 passed, 0 failed
- [x] Existing `mcp-client.test.ts` — 12 passed, 0 failed
- [x] `pnpm turbo build` — 31/31 successful
- [x] `pnpm turbo lint` — 25/25 successful
- [x] `pnpm turbo test` — 26/26 successful

closes #423