### PR TITLE
fix(#424): quality-assurance Level 2 — executeWithRetry + permanent halt guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`executeLoop` halts on permanent failures + executeWithRetry in quality-assurance agent** (#424) — Added `executeWithRetry` with 3-attempt exponential backoff and permanent halt guard (`!execResult.retryable`). Matching the geologist Level 2 reference. 2 new contract tests.
+
 - **`executeLoop` halts on permanent failures in economist agent** (#423) — `else` branch in `runEconomistTask`'s `executeLoop` previously logged a hint string and continued when `execResult.retryable === false`. Now returns immediately, matching the geologist Level 2 reference. Adds 2 contract tests verifying blocking eval halts the loop.
 
 - **`executeLoop` now halts on permanent failures** (#404) — `runGeologistTask`'s `executeLoop` previously pushed non-retryable errors (blocking evals, scope rejections) into the conversation history and continued the task loop. Now returns immediately when `execResult.retryable === false`, so safety gates actually stop execution. Adds 7 tests to `agents/geologist/tests/agent.test.ts` covering `redactSecrets` blocking on `sk-` output and advisory schema completing with a warn.

--- a/agents/quality-assurance/CHANGELOG.md
+++ b/agents/quality-assurance/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 - **Layer 2 execution loop** (#376) — `runQAAssuranceTask(goal, options)` drives a multi-step QA task via the LLM. Accepts a natural-language goal, reasons about which qa-server tools to call, routes every tool call through `LocalAgentRuntime.execute()` (Permission Gate — HITL + scope checks fire on every step), and returns a synthesized answer. Accepts `runtime?: LocalAgentRuntime` (caller-managed lifecycle) and `onApprovalRequired?: (challenge) => Promise<HumanApproval>` (HITL callback). Throws with a clear message when `approval_required` and no callback provided. Deferred: Context Injection (#395), Async Job (#396).
 
+### Fixed
+
+- **`executeLoop` halts on permanent failures + executeWithRetry added** (#424) — Two Level 2 gaps addressed: (1) `runtime.execute()` now wrapped by `executeWithRetry` with 3-attempt exponential backoff (500ms/1s/2s) for transient failures; (2) `else` branch now halts immediately when `execResult.retryable === false` (blocking evals, scope rejections) instead of logging a hint and continuing. Adds 2 contract tests: blocking schema eval halts the loop and returns a non-empty error string.
+
 ### Changed
 
 - **Model routing wired into `callLLM`** (#402) — `executeLoop` now resolves `config.modelRouting["standard-analysis"].model` and passes it to every `callLLM()` call. Previously the loop omitted the `model` parameter. Adds a throw guard when `standard-analysis` is absent. `qaAssuranceConfig` dev defaults replaced `"configured-by-operator"` placeholder strings with real Anthropic model IDs.

--- a/agents/quality-assurance/src/agent/index.ts
+++ b/agents/quality-assurance/src/agent/index.ts
@@ -287,6 +287,28 @@ function parseJson(
 	}
 }
 
+// Retry budgets — Arcade pattern #40: Error Classification.
+// Retryable errors (network transients, server restarts) get up to MAX_TOOL_RETRIES attempts
+// with exponential backoff before the error is surfaced to the LLM as a recoverable hint.
+const MAX_TOOL_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 500;
+
+async function executeWithRetry(
+	runtime: LocalAgentRuntime,
+	request: Parameters<typeof runtime.execute>[0],
+): Promise<ReturnType<LocalAgentRuntime["execute"]>> {
+	let last: Awaited<ReturnType<LocalAgentRuntime["execute"]>> | null = null;
+	for (let attempt = 0; attempt <= MAX_TOOL_RETRIES; attempt++) {
+		if (attempt > 0) {
+			await new Promise((r) => setTimeout(r, RETRY_BASE_DELAY_MS * 2 ** (attempt - 1)));
+		}
+		const result = await runtime.execute(request);
+		if (result.status !== "failed" || !result.retryable) return result;
+		last = result;
+	}
+	return last!;
+}
+
 async function executeLoop(
 	goal: string,
 	runtime: LocalAgentRuntime,
@@ -351,7 +373,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 		// TODO (#396): Async Job — detect long-running test suites and poll for completion.
 
 		// Permission Gate: route through runtime.execute() so HITL + scope checks fire.
-		const execResult = await runtime.execute({
+		// executeWithRetry transparently retries transient (retryable) failures before
+		// surfacing the error to the LLM as a recoverable hint.
+		const execResult = await executeWithRetry(runtime, {
 			toolName: parsed.tool,
 			args: parsed.args ?? {},
 			runId: `task:step:${step}`,
@@ -380,8 +404,16 @@ If you cannot complete the task with the available tools, respond with {"action"
 				history.push({ role: "tool", content: `Error after approval for ${parsed.tool}: ${err}` });
 			}
 		} else {
-			const hint = execResult.retryable ? " (retryable — server may be temporarily unavailable)" : " (permanent)";
-			history.push({ role: "tool", content: `Error calling ${parsed.tool}: ${execResult.error}${hint}` });
+			// Permanent failure (blocking eval, scope rejection, unretryable error) — safety gate,
+			// do not continue the loop. The LLM cannot recover from a security or governance halt.
+			if (!execResult.retryable) {
+				return execResult.error ?? `Permanent failure calling ${parsed.tool}`;
+			}
+			// Transient failure — push to history so the LLM can reformulate and retry.
+			history.push({
+				role: "tool",
+				content: `Error calling ${parsed.tool}: ${execResult.error} (retryable — server may be temporarily unavailable)`,
+			});
 		}
 	}
 

--- a/agents/quality-assurance/tests/agent.test.ts
+++ b/agents/quality-assurance/tests/agent.test.ts
@@ -248,6 +248,51 @@ console.log("\n🔀 Testing model routing wired into callLLM (issue #402)...");
 	assert(capturedModels[0] === "claude-sonnet-4-6", "QA executeLoop passes standard-analysis model to callLLM");
 }
 
+console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #424)...");
+{
+	// A blocking schema eval sets retryable: false on execute(). executeLoop must
+	// immediately return the error — do not continue to the next LLM step.
+	// Without the fix, the else branch logs the hint and calls the LLM a second time.
+	const blockingConfig: typeof qaAssuranceConfig = {
+		...qaAssuranceConfig,
+		evals: {
+			...qaAssuranceConfig.evals,
+			checks: { ...qaAssuranceConfig.evals.checks, schema: "blocking" },
+		},
+	};
+	const blockingRuntime = new LocalAgentRuntime({
+		manifest: qaAssuranceManifest,
+		config: blockingConfig,
+		// Handler returns undefined — triggers blocking schema eval failure on execute()
+		handlers: Object.fromEntries(qaAssuranceManifest.tools.map((t) => [t.name, async () => undefined])),
+	});
+	await blockingRuntime.initialize();
+
+	const llmCallCount: number[] = [];
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		llmCallCount.push(1);
+		if (llmCallCount.length === 1) {
+			return JSON.stringify({
+				action: "tool",
+				tool: "quality-assurance.run_quality_tests",
+				args: { testSuite: "unit", targetPath: "./src" },
+			});
+		}
+		return JSON.stringify({ action: "done", answer: "should not reach here" });
+	};
+
+	const result = await runQAAssuranceTask("run unit tests", {
+		config: blockingConfig,
+		callLLM: mockLLM,
+		runtime: blockingRuntime,
+	});
+
+	assert(llmCallCount.length === 1, "executeLoop halts after permanent failure — LLM not called a second time");
+	assert(typeof result === "string" && result.length > 0, "Permanent failure returns non-empty error string");
+
+	await blockingRuntime.shutdown();
+}
+
 console.log("\n🛑 Testing invalid manifest fails early...");
 {
 	try {


### PR DESCRIPTION
## Summary

- Added `executeWithRetry` with 3-attempt exponential backoff (500ms/1s/2s) for transient failures — previously `runtime.execute()` was called directly with no retry
- Fixed `else` branch: now halts immediately when `execResult.retryable === false` (blocking evals, scope rejections, security gates) instead of logging a hint and continuing
- Approval re-execute path keeps `runtime.execute()` direct — no retry after explicit human approval
- Brings `quality-assurance` to Level 2 parity with the geologist reference

## Test plan

- [x] New test: blocking schema eval (`retryable: false`) — `llmCallCount.length === 1` (loop halted) + non-empty error string returned
- [x] `agent.test.ts` — 44 passed, 0 failed
- [x] `mcp-client.test.ts` — 12 passed, 0 failed
- [x] `pnpm turbo build` — 31/31
- [x] `pnpm turbo lint` — 25/25 (QA clean; other warnings pre-existing)
- [x] `pnpm turbo test` — 26/26

closes #424