### PR TITLE
fix(#425): development-planner Level 2 — permanent halt guard + injectable callLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`executeLoop` permanent halt guard + injectable `callLLM` in development-planner** (#425) — `else` branch now halts on `!execResult.retryable`; wires injectable `callLLM` option through to `executeLoop`. 2 new contract tests.
+
 - **`executeLoop` halts on permanent failures + executeWithRetry in quality-assurance agent** (#424) — Added `executeWithRetry` with 3-attempt exponential backoff and permanent halt guard (`!execResult.retryable`). Matching the geologist Level 2 reference. 2 new contract tests.
 
 - **`executeLoop` halts on permanent failures in economist agent** (#423) — `else` branch in `runEconomistTask`'s `executeLoop` previously logged a hint string and continued when `execResult.retryable === false`. Now returns immediately, matching the geologist Level 2 reference. Adds 2 contract tests verifying blocking eval halts the loop.

--- a/agents/development-planner/CHANGELOG.md
+++ b/agents/development-planner/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`executeLoop` permanent halt guard + injectable `callLLM`** (#425) — `else` branch now returns immediately when `execResult.retryable === false` (blocking evals, scope rejections), matching geologist Level 2 reference. Also wires `options.callLLM` injectable through to `executeLoop` so tests can drive the model without a real API key. Adds 2 contract tests verifying loop halt on permanent failure.
+
 ## [0.1.0] — 2026-06-10
 
 ### Added

--- a/agents/development-planner/src/agent/index.ts
+++ b/agents/development-planner/src/agent/index.ts
@@ -1,5 +1,11 @@
 import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
-import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import {
+	callLLM,
+	type LLMCallOptions,
+	LocalAgentEndpoint,
+	LocalAgentRuntime,
+	type StandaloneToolHandler,
+} from "@shaleyeah/sdk";
 import { callDevelopmentTool } from "./development-client.js";
 
 export { callDevelopmentTool };
@@ -258,6 +264,8 @@ export async function runDevelopmentPlannerTask(
 		apiKey?: string;
 		runtime?: LocalAgentRuntime;
 		onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+		/** Inject a custom LLM function — used in tests to capture model routing without real API calls. */
+		callLLM?: (opts: LLMCallOptions) => Promise<string>;
 	} = {},
 ): Promise<string> {
 	const config = options.config ?? developmentPlannerConfig;
@@ -271,7 +279,7 @@ export async function runDevelopmentPlannerTask(
 	}
 
 	try {
-		return await executeLoop(goal, runtime, { ...options, config });
+		return await executeLoop(goal, runtime, { ...options, config, callLLMFn: options.callLLM ?? callLLM });
 	} finally {
 		if (ownedRuntime) await runtime.shutdown();
 	}
@@ -331,11 +339,13 @@ async function executeLoop(
 		config?: AgentRuntimeConfig;
 		apiKey?: string;
 		onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
 	// TODO (#395): Context Injection — read from memory.namespace before building system prompt.
 
 	const config = options.config ?? developmentPlannerConfig;
+	const callLLMFn = options.callLLMFn ?? callLLM;
 	const reasoningModel = config.modelRouting["standard-analysis"]?.model;
 
 	const toolDefs = developmentPlannerManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
@@ -357,7 +367,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 	const MAX_STEPS = 8;
 
 	for (let step = 0; step < MAX_STEPS; step++) {
-		const response = await callLLM({
+		const response = await callLLMFn({
 			system,
 			prompt: `${buildTranscript(history)}\n\nAssistant:`,
 			model: reasoningModel,
@@ -405,17 +415,22 @@ If you cannot complete the task with the available tools, respond with {"action"
 				});
 			}
 		} else {
-			const hint = execResult.retryable ? " (retryable — server may be temporarily unavailable)" : " (permanent)";
+			// Permanent failure (blocking eval, scope rejection, unretryable error) — safety gate,
+			// do not continue the loop. The LLM cannot recover from a security or governance halt.
+			if (!execResult.retryable) {
+				return execResult.error ?? `Permanent failure calling ${parsed.tool}`;
+			}
+			// Transient failure — push to history so the LLM can reformulate and retry.
 			history.push({
 				role: "tool",
-				content: `Error calling ${parsed.tool}: ${execResult.error}${hint}`,
+				content: `Error calling ${parsed.tool}: ${execResult.error} (retryable — server may be temporarily unavailable)`,
 			});
 		}
 	}
 
 	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
 
-	const finalResponse = await callLLM({
+	const finalResponse = await callLLMFn({
 		system,
 		prompt: `${buildTranscript(history)}\n\nUser: Maximum steps reached. Synthesize findings now.\n\nAssistant:`,
 		model: reasoningModel,

--- a/agents/development-planner/tests/agent.test.ts
+++ b/agents/development-planner/tests/agent.test.ts
@@ -5,12 +5,13 @@
  * and that the development-planner manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, LocalAgentRuntime } from "@shaleyeah/sdk";
+import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
 import {
 	createDevelopmentPlannerEndpoint,
 	createDevelopmentPlannerRuntime,
 	developmentPlannerConfig,
 	developmentPlannerManifest,
+	runDevelopmentPlannerTask,
 } from "../src/agent/index.js";
 
 let passed = 0;
@@ -187,6 +188,47 @@ console.log("\n🏥 Testing health endpoint and standalone boot...");
 
 	const toolSchema = await endpoint.discoveryToolSchema("development-planner.create_development_plan");
 	assert(toolSchema !== null, "Endpoint exposes tool schemas by name");
+}
+
+console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #425)...");
+{
+	const blockingConfig: typeof developmentPlannerConfig = {
+		...developmentPlannerConfig,
+		evals: {
+			...developmentPlannerConfig.evals,
+			checks: { ...developmentPlannerConfig.evals.checks, schema: "blocking" },
+		},
+	};
+	const blockingRuntime = new LocalAgentRuntime({
+		manifest: developmentPlannerManifest,
+		config: blockingConfig,
+		handlers: Object.fromEntries(developmentPlannerManifest.tools.map((t) => [t.name, async () => undefined])),
+	});
+	await blockingRuntime.initialize();
+
+	const llmCallCount: number[] = [];
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		llmCallCount.push(1);
+		if (llmCallCount.length === 1) {
+			return JSON.stringify({
+				action: "tool",
+				tool: "development-planner.create_development_plan",
+				args: { wellName: "Test-1", reservoirData: {} },
+			});
+		}
+		return JSON.stringify({ action: "done", answer: "should not reach here" });
+	};
+
+	const result = await runDevelopmentPlannerTask("create a plan", {
+		config: blockingConfig,
+		callLLM: mockLLM,
+		runtime: blockingRuntime,
+	});
+
+	assert(llmCallCount.length === 1, "executeLoop halts after permanent failure — LLM not called a second time");
+	assert(typeof result === "string" && result.length > 0, "Permanent failure returns non-empty error string");
+
+	await blockingRuntime.shutdown();
 }
 
 console.log("\n🛑 Testing invalid manifest fails early...");


### PR DESCRIPTION
## Summary

- Permanent halt guard: `else` branch now returns immediately when `execResult.retryable === false` — previously logged a hint and continued the loop
- Injectable `callLLM`: wires `options.callLLM` through `runDevelopmentPlannerTask` → `executeLoop` so tests can drive the model without a real API key (parity with geologist/economist/QA)
- `executeWithRetry` was already present; only the halt guard and injectable option were missing

## Test plan

- [x] New test: blocking schema eval halts loop — `llmCallCount.length === 1` + non-empty error string
- [x] `agent.test.ts` — 44 passed, 0 failed
- [x] `pnpm turbo build --filter` — clean
- [x] `pnpm turbo lint --filter` — clean

closes #425