### PR TITLE
fix(#426): drilling-engineer Level 2 — executeWithRetry + permanent halt guard + injectable callLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`executeLoop` halts on permanent failures + executeWithRetry + injectable callLLM in drilling-engineer agent** (#426) — Added `executeWithRetry` with 3-attempt exponential backoff, permanent halt guard (`!execResult.retryable`), and `callLLM?` injectable option to `runDrillingEngineerTask`. 2 new contract tests.
+
 - **`executeLoop` halts on permanent failures + executeWithRetry in quality-assurance agent** (#424) — Added `executeWithRetry` with 3-attempt exponential backoff and permanent halt guard (`!execResult.retryable`). Matching the geologist Level 2 reference. 2 new contract tests.
 
 - **`executeLoop` halts on permanent failures in economist agent** (#423) — `else` branch in `runEconomistTask`'s `executeLoop` previously logged a hint string and continued when `execResult.retryable === false`. Now returns immediately, matching the geologist Level 2 reference. Adds 2 contract tests verifying blocking eval halts the loop.

--- a/agents/drilling-engineer/CHANGELOG.md
+++ b/agents/drilling-engineer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`executeLoop` halts on permanent failures + executeWithRetry + injectable callLLM** (#426) — Added `executeWithRetry` with 3-attempt exponential backoff, permanent halt guard (`!execResult.retryable`), and `callLLM?` injectable option. Matching the geologist Level 2 reference. 2 new contract tests.
+
 ## [0.1.0] — 2026-06-10
 
 ### Added

--- a/agents/drilling-engineer/src/agent/index.ts
+++ b/agents/drilling-engineer/src/agent/index.ts
@@ -1,5 +1,11 @@
 import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
-import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import {
+	callLLM,
+	type LLMCallOptions,
+	LocalAgentEndpoint,
+	LocalAgentRuntime,
+	type StandaloneToolHandler,
+} from "@shaleyeah/sdk";
 import { callDrillingTool } from "./drilling-client.js";
 
 export { callDrillingTool };
@@ -272,6 +278,8 @@ export async function runDrillingEngineerTask(
 		apiKey?: string;
 		runtime?: LocalAgentRuntime;
 		onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+		/** Inject a custom LLM function — used in tests to capture model routing without real API calls. */
+		callLLM?: (opts: LLMCallOptions) => Promise<string>;
 	} = {},
 ): Promise<string> {
 	const config = options.config ?? drillingEngineerConfig;
@@ -285,7 +293,7 @@ export async function runDrillingEngineerTask(
 	}
 
 	try {
-		return await executeLoop(goal, runtime, options);
+		return await executeLoop(goal, runtime, { ...options, callLLMFn: options.callLLM ?? callLLM });
 	} finally {
 		if (ownedRuntime) await runtime.shutdown();
 	}
@@ -318,16 +326,40 @@ function parseJson(text: string): {
 	}
 }
 
+// Retry budgets — Arcade pattern #40: Error Classification.
+// Retryable errors (network transients, server restarts) get up to MAX_TOOL_RETRIES attempts
+// with exponential backoff before the error is surfaced to the LLM as a recoverable hint.
+const MAX_TOOL_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 500;
+
+async function executeWithRetry(
+	runtime: LocalAgentRuntime,
+	request: Parameters<typeof runtime.execute>[0],
+): Promise<ReturnType<LocalAgentRuntime["execute"]>> {
+	let last: Awaited<ReturnType<LocalAgentRuntime["execute"]>> | null = null;
+	for (let attempt = 0; attempt <= MAX_TOOL_RETRIES; attempt++) {
+		if (attempt > 0) {
+			await new Promise((r) => setTimeout(r, RETRY_BASE_DELAY_MS * 2 ** (attempt - 1)));
+		}
+		const result = await runtime.execute(request);
+		if (result.status !== "failed" || !result.retryable) return result;
+		last = result;
+	}
+	return last!;
+}
+
 async function executeLoop(
 	goal: string,
 	runtime: LocalAgentRuntime,
 	options: {
 		apiKey?: string;
 		onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
 	// TODO (#395): Context Injection — read from memory.namespace before building system prompt.
 
+	const callLLMFn = options.callLLMFn ?? callLLM;
 	const toolDefs = drillingEngineerManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
 
 	const system = `You are ${drillingEngineerManifest.persona.name}, ${drillingEngineerManifest.persona.role}.
@@ -347,7 +379,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 	const MAX_STEPS = 8;
 
 	for (let step = 0; step < MAX_STEPS; step++) {
-		const response = await callLLM({
+		const response = await callLLMFn({
 			system,
 			prompt: `${buildTranscript(history)}\n\nAssistant:`,
 			apiKey: options.apiKey,
@@ -362,9 +394,10 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		// TODO (#396): Async Job — detect asyncJob tools and poll instead of blocking.
 
-		// Permission Gate: all tool calls go through runtime.execute() — never call
-		// the MCP client directly from the loop.
-		const execResult = await runtime.execute({
+		// Permission Gate: route through runtime.execute() so HITL + scope checks fire.
+		// executeWithRetry transparently retries transient (retryable) failures before
+		// surfacing the error to the LLM as a recoverable hint.
+		const execResult = await executeWithRetry(runtime, {
 			toolName: parsed.tool,
 			args: parsed.args ?? {},
 			runId: `task:step:${step}`,
@@ -395,17 +428,22 @@ If you cannot complete the task with the available tools, respond with {"action"
 				});
 			}
 		} else {
-			const hint = execResult.retryable ? " (retryable — server may be temporarily unavailable)" : " (permanent)";
+			// Permanent failure (blocking eval, scope rejection, unretryable error) — safety gate,
+			// do not continue the loop. The LLM cannot recover from a security or governance halt.
+			if (!execResult.retryable) {
+				return execResult.error ?? `Permanent failure calling ${parsed.tool}`;
+			}
+			// Transient failure — push to history so the LLM can reformulate and retry.
 			history.push({
 				role: "tool",
-				content: `Error calling ${parsed.tool}: ${execResult.error}${hint}`,
+				content: `Error calling ${parsed.tool}: ${execResult.error} (retryable — server may be temporarily unavailable)`,
 			});
 		}
 	}
 
 	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
 
-	const finalResponse = await callLLM({
+	const finalResponse = await callLLMFn({
 		system,
 		prompt: `${buildTranscript(history)}\n\nUser: Maximum steps reached. Synthesize findings now.\n\nAssistant:`,
 		apiKey: options.apiKey,

--- a/agents/drilling-engineer/tests/agent.test.ts
+++ b/agents/drilling-engineer/tests/agent.test.ts
@@ -5,12 +5,13 @@
  * and that the drilling-engineer manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, LocalAgentRuntime } from "@shaleyeah/sdk";
+import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
 import {
 	createDrillingEngineerEndpoint,
 	createDrillingEngineerRuntime,
 	drillingEngineerConfig,
 	drillingEngineerManifest,
+	runDrillingEngineerTask,
 } from "../src/agent/index.js";
 
 let passed = 0;
@@ -328,6 +329,47 @@ console.log("\n🔀 Testing model routing resolution...");
 		"standard-analysis model is a real model ID, not a placeholder",
 	);
 	assert(standardAnalysis?.provider === "anthropic", "standard-analysis provider is anthropic");
+}
+
+console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #426)...");
+{
+	const blockingConfig: typeof drillingEngineerConfig = {
+		...drillingEngineerConfig,
+		evals: {
+			...drillingEngineerConfig.evals,
+			checks: { ...drillingEngineerConfig.evals.checks, schema: "blocking" },
+		},
+	};
+	const blockingRuntime = new LocalAgentRuntime({
+		manifest: drillingEngineerManifest,
+		config: blockingConfig,
+		handlers: Object.fromEntries(drillingEngineerManifest.tools.map((t) => [t.name, async () => undefined])),
+	});
+	await blockingRuntime.initialize();
+
+	const llmCallCount: number[] = [];
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		llmCallCount.push(1);
+		if (llmCallCount.length === 1) {
+			return JSON.stringify({
+				action: "tool",
+				tool: "drilling-engineer.design_drilling_program",
+				args: { wellName: "Test-1", targetDepth: 10000, wellType: "vertical" },
+			});
+		}
+		return JSON.stringify({ action: "done", answer: "should not reach here" });
+	};
+
+	const result = await runDrillingEngineerTask("design a drilling program", {
+		config: blockingConfig,
+		callLLM: mockLLM,
+		runtime: blockingRuntime,
+	});
+
+	assert(llmCallCount.length === 1, "executeLoop halts after permanent failure — LLM not called a second time");
+	assert(typeof result === "string" && result.length > 0, "Permanent failure returns non-empty error string");
+
+	await blockingRuntime.shutdown();
 }
 
 console.log("\n🛑 Testing invalid manifest fails early...");


### PR DESCRIPTION
## Summary

- Adds `executeWithRetry` with 3-attempt exponential backoff (500ms/1s/2s) for transient tool failures
- Fixes `else` branch in `executeLoop` to return immediately on permanent failures (`!execResult.retryable`) — blocking evals, scope rejections, and security gates now halt the loop
- Wires `callLLM?` injectable option through `runDrillingEngineerTask` → `executeLoop` for testing without a real API key

Closes #426

## Test plan

- [x] 36/36 tests pass (`npx tsx tests/agent.test.ts` + `npx tsx tests/mcp-client.test.ts`)
- [x] New permanent-halt test: blocking schema eval triggers 1 LLM call, loop halts, returns non-empty error string
- [x] Lint clean (`pnpm turbo lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)