### PR TITLE
fix(#427): infrastructure-planner Level 2 — executeWithRetry + permanent halt guard + injectable callLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`executeLoop` halts on permanent failures + executeWithRetry + injectable callLLM in infrastructure-planner agent** (#427) — Added `executeWithRetry` with 3-attempt exponential backoff, permanent halt guard (`!execResult.retryable`), model routing, and `callLLM?` injectable option to `runInfrastructurePlannerTask`. 2 new contract tests.
+
 - **`executeLoop` halts on permanent failures + executeWithRetry in quality-assurance agent** (#424) — Added `executeWithRetry` with 3-attempt exponential backoff and permanent halt guard (`!execResult.retryable`). Matching the geologist Level 2 reference. 2 new contract tests.
 
 - **`executeLoop` halts on permanent failures in economist agent** (#423) — `else` branch in `runEconomistTask`'s `executeLoop` previously logged a hint string and continued when `execResult.retryable === false`. Now returns immediately, matching the geologist Level 2 reference. Adds 2 contract tests verifying blocking eval halts the loop.

--- a/agents/infrastructure-planner/CHANGELOG.md
+++ b/agents/infrastructure-planner/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`executeLoop` halts on permanent failures + executeWithRetry + injectable callLLM** (#427) — Added `executeWithRetry` with 3-attempt exponential backoff, permanent halt guard (`!execResult.retryable`), model routing via `reasoningModel`, and `callLLM?` injectable option. Matching the geologist Level 2 reference. 2 new contract tests.
+
 ### Added
 
 - **Step B: Tier 2 agent implementation** (#375) — Full infrastructure-planner agent replacing the stub:

--- a/agents/infrastructure-planner/src/agent/index.ts
+++ b/agents/infrastructure-planner/src/agent/index.ts
@@ -1,5 +1,11 @@
 import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
-import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import {
+	callLLM,
+	type LLMCallOptions,
+	LocalAgentEndpoint,
+	LocalAgentRuntime,
+	type StandaloneToolHandler,
+} from "@shaleyeah/sdk";
 import { callInfrastructureTool } from "./infrastructure-client.js";
 
 export { callInfrastructureTool };
@@ -278,6 +284,8 @@ export async function runInfrastructurePlannerTask(
 		apiKey?: string;
 		runtime?: LocalAgentRuntime;
 		onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+		/** Inject a custom LLM function — used in tests to capture model routing without real API calls. */
+		callLLM?: (opts: LLMCallOptions) => Promise<string>;
 	} = {},
 ): Promise<string> {
 	const config = options.config ?? infrastructurePlannerConfig;
@@ -291,7 +299,7 @@ export async function runInfrastructurePlannerTask(
 	}
 
 	try {
-		return await executeLoop(goal, runtime, options);
+		return await executeLoop(goal, runtime, { ...options, config, callLLMFn: options.callLLM ?? callLLM });
 	} finally {
 		if (ownedRuntime) await runtime.shutdown();
 	}
@@ -324,14 +332,48 @@ function parseJson(text: string): {
 	}
 }
 
+// Retry budgets — Arcade pattern #40: Error Classification.
+const MAX_TOOL_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 500;
+
+async function executeWithRetry(
+	runtime: LocalAgentRuntime,
+	request: Parameters<typeof runtime.execute>[0],
+): Promise<ReturnType<LocalAgentRuntime["execute"]>> {
+	let last: Awaited<ReturnType<LocalAgentRuntime["execute"]>> | null = null;
+	for (let attempt = 0; attempt <= MAX_TOOL_RETRIES; attempt++) {
+		if (attempt > 0) {
+			await new Promise((r) => setTimeout(r, RETRY_BASE_DELAY_MS * 2 ** (attempt - 1)));
+		}
+		const result = await runtime.execute(request);
+		if (result.status !== "failed" || !result.retryable) return result;
+		last = result;
+	}
+	return last!;
+}
+
 async function executeLoop(
 	goal: string,
 	runtime: LocalAgentRuntime,
 	options: {
+		config?: AgentRuntimeConfig;
 		apiKey?: string;
 		onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
+	const config = options.config ?? infrastructurePlannerConfig;
+	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	const standardAnalysisBinding = config.modelRouting["standard-analysis"];
+	if (!standardAnalysisBinding) {
+		throw new Error(
+			`[infrastructure-planner] modelRouting is missing a "standard-analysis" entry. ` +
+				'Configure AgentRuntimeConfig.modelRouting["standard-analysis"] before calling runInfrastructurePlannerTask.',
+		);
+	}
+	const reasoningModel = standardAnalysisBinding.model;
+
 	const toolDefs = infrastructurePlannerManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
 
 	const system = `You are ${infrastructurePlannerManifest.persona.name}, ${infrastructurePlannerManifest.persona.role}.
@@ -351,9 +393,10 @@ If you cannot complete the task with the available tools, respond with {"action"
 	const MAX_STEPS = 8;
 
 	for (let step = 0; step < MAX_STEPS; step++) {
-		const response = await callLLM({
+		const response = await callLLMFn({
 			system,
 			prompt: `${buildTranscript(history)}\n\nAssistant:`,
+			model: reasoningModel,
 			apiKey: options.apiKey,
 		});
 
@@ -364,7 +407,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 			return parsed?.answer ?? response;
 		}
 
-		const execResult = await runtime.execute({
+		const execResult = await executeWithRetry(runtime, {
 			toolName: parsed.tool,
 			args: parsed.args ?? {},
 			runId: `task:step:${step}`,
@@ -396,17 +439,23 @@ If you cannot complete the task with the available tools, respond with {"action"
 				});
 			}
 		} else {
-			const hint = execResult.retryable ? " (retryable — server may be temporarily unavailable)" : " (permanent)";
+			// Permanent failure (blocking eval, scope rejection, unretryable error) — safety gate,
+			// do not continue the loop. The LLM cannot recover from a security or governance halt.
+			if (!execResult.retryable) {
+				return execResult.error ?? `Permanent failure calling ${parsed.tool}`;
+			}
+			// Transient failure — push to history so the LLM can reformulate and retry.
 			history.push({
 				role: "tool",
-				content: `Error calling ${parsed.tool}: ${execResult.error}${hint}`,
+				content: `Error calling ${parsed.tool}: ${execResult.error} (retryable — server may be temporarily unavailable)`,
 			});
 		}
 	}
 
-	const finalResponse = await callLLM({
+	const finalResponse = await callLLMFn({
 		system,
 		prompt: `${buildTranscript(history)}\n\nUser: Maximum steps reached. Synthesize findings now.\n\nAssistant:`,
+		model: reasoningModel,
 		apiKey: options.apiKey,
 	});
 

--- a/agents/infrastructure-planner/tests/agent.test.ts
+++ b/agents/infrastructure-planner/tests/agent.test.ts
@@ -6,12 +6,13 @@
  * acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, LocalAgentRuntime } from "@shaleyeah/sdk";
+import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
 import {
 	createInfrastructurePlannerEndpoint,
 	createInfrastructurePlannerRuntime,
 	infrastructurePlannerConfig,
 	infrastructurePlannerManifest,
+	runInfrastructurePlannerTask,
 } from "../src/agent/index.js";
 
 let passed = 0;
@@ -269,6 +270,47 @@ console.log("\n🧱 Testing blocking eval halt...");
 		assert(result.retryable === false, "Blocking eval failures are not retryable");
 	}
 	await testRuntime.shutdown();
+}
+
+console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #427)...");
+{
+	const blockingConfig: typeof infrastructurePlannerConfig = {
+		...infrastructurePlannerConfig,
+		evals: {
+			...infrastructurePlannerConfig.evals,
+			checks: { ...infrastructurePlannerConfig.evals.checks, schema: "blocking" },
+		},
+	};
+	const blockingRuntime = new LocalAgentRuntime({
+		manifest: infrastructurePlannerManifest,
+		config: blockingConfig,
+		handlers: Object.fromEntries(infrastructurePlannerManifest.tools.map((t) => [t.name, async () => undefined])),
+	});
+	await blockingRuntime.initialize();
+
+	const llmCallCount: number[] = [];
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		llmCallCount.push(1);
+		if (llmCallCount.length === 1) {
+			return JSON.stringify({
+				action: "tool",
+				tool: "infrastructure-planner.plan_pipeline",
+				args: { wellCount: 10, expectedProduction: 500, location: "Reeves County, Texas" },
+			});
+		}
+		return JSON.stringify({ action: "done", answer: "should not reach here" });
+	};
+
+	const result = await runInfrastructurePlannerTask("Plan pipeline infrastructure", {
+		config: blockingConfig,
+		callLLM: mockLLM,
+		runtime: blockingRuntime,
+	});
+
+	assert(llmCallCount.length === 1, "executeLoop halts after permanent failure — LLM not called a second time");
+	assert(typeof result === "string" && result.length > 0, "Permanent failure returns non-empty error string");
+
+	await blockingRuntime.shutdown();
 }
 
 console.log("\n🛑 Testing invalid manifest fails early...");


### PR DESCRIPTION
## Summary

- Adds `executeWithRetry` with 3-attempt exponential backoff (500ms/1s/2s) for transient tool failures
- Fixes `else` branch in `executeLoop` to return immediately on permanent failures (`!execResult.retryable`)
- Wires `callLLM?` injectable option through `runInfrastructurePlannerTask` → `executeLoop`
- Adds model routing (`reasoningModel` from `config.modelRouting["standard-analysis"]`) to both `callLLMFn` calls

Closes #427

## Test plan

- [x] 33/33 tests pass (`npx tsx tests/agent.test.ts`)
- [x] New permanent-halt test: blocking schema eval triggers 1 LLM call, loop halts, returns non-empty error string
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)