### PR TITLE
fix(#428): legal-analyst Level 2 — permanent halt guard + injectable callLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`executeLoop` halts on permanent failures + injectable callLLM in legal-analyst agent** (#428) — Added permanent halt guard (`!execResult.retryable`), `callLLM?` injectable option, and throw guard for missing `standard-analysis` model route. 2 new contract tests.
+
 - **`executeLoop` halts on permanent failures + executeWithRetry in quality-assurance agent** (#424) — Added `executeWithRetry` with 3-attempt exponential backoff and permanent halt guard (`!execResult.retryable`). Matching the geologist Level 2 reference. 2 new contract tests.
 
 - **`executeLoop` halts on permanent failures in economist agent** (#423) — `else` branch in `runEconomistTask`'s `executeLoop` previously logged a hint string and continued when `execResult.retryable === false`. Now returns immediately, matching the geologist Level 2 reference. Adds 2 contract tests verifying blocking eval halts the loop.

--- a/agents/legal-analyst/CHANGELOG.md
+++ b/agents/legal-analyst/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`executeLoop` halts on permanent failures + injectable callLLM** (#428) — Added permanent halt guard (`!execResult.retryable`), `callLLM?` injectable option, throw guard for missing `standard-analysis` model route, and threaded `callLLMFn` through both LLM call sites. Matching the geologist Level 2 reference. 2 new contract tests.
+
 ## [0.1.0] — 2026-06-10
 
 ### Added

--- a/agents/legal-analyst/src/agent/index.ts
+++ b/agents/legal-analyst/src/agent/index.ts
@@ -1,5 +1,11 @@
 import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
-import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import {
+	callLLM,
+	type LLMCallOptions,
+	LocalAgentEndpoint,
+	LocalAgentRuntime,
+	type StandaloneToolHandler,
+} from "@shaleyeah/sdk";
 import { callLegalTool } from "./legal-client.js";
 
 export { callLegalTool };
@@ -266,6 +272,8 @@ export async function runLegalAnalystTask(
 		apiKey?: string;
 		runtime?: LocalAgentRuntime;
 		onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+		/** Inject a custom LLM function — used in tests to capture model routing without real API calls. */
+		callLLM?: (opts: LLMCallOptions) => Promise<string>;
 	} = {},
 ): Promise<string> {
 	const config = options.config ?? legalAnalystConfig;
@@ -279,7 +287,7 @@ export async function runLegalAnalystTask(
 	}
 
 	try {
-		return await executeLoop(goal, runtime, { ...options, config });
+		return await executeLoop(goal, runtime, { ...options, config, callLLMFn: options.callLLM ?? callLLM });
 	} finally {
 		if (ownedRuntime) await runtime.shutdown();
 	}
@@ -340,12 +348,22 @@ async function executeLoop(
 		config?: AgentRuntimeConfig;
 		apiKey?: string;
 		onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
 	// TODO (#395): Context Injection — read from memory.namespace before building system prompt.
 
 	const config = options.config ?? legalAnalystConfig;
-	const reasoningModel = config.modelRouting["standard-analysis"]?.model;
+	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	const standardAnalysisBinding = config.modelRouting["standard-analysis"];
+	if (!standardAnalysisBinding) {
+		throw new Error(
+			`[legal-analyst] modelRouting is missing a "standard-analysis" entry. ` +
+				'Configure AgentRuntimeConfig.modelRouting["standard-analysis"] before calling runLegalAnalystTask.',
+		);
+	}
+	const reasoningModel = standardAnalysisBinding.model;
 
 	const toolDefs = legalAnalystManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
 
@@ -366,7 +384,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 	const MAX_STEPS = 8;
 
 	for (let step = 0; step < MAX_STEPS; step++) {
-		const response = await callLLM({
+		const response = await callLLMFn({
 			system,
 			prompt: `${buildTranscript(history)}\n\nAssistant:`,
 			model: reasoningModel,
@@ -414,17 +432,22 @@ If you cannot complete the task with the available tools, respond with {"action"
 				});
 			}
 		} else {
-			const hint = execResult.retryable ? " (retryable — server may be temporarily unavailable)" : " (permanent)";
+			// Permanent failure (blocking eval, scope rejection, unretryable error) — safety gate,
+			// do not continue the loop. The LLM cannot recover from a security or governance halt.
+			if (!execResult.retryable) {
+				return execResult.error ?? `Permanent failure calling ${parsed.tool}`;
+			}
+			// Transient failure — push to history so the LLM can reformulate and retry.
 			history.push({
 				role: "tool",
-				content: `Error calling ${parsed.tool}: ${execResult.error}${hint}`,
+				content: `Error calling ${parsed.tool}: ${execResult.error} (retryable — server may be temporarily unavailable)`,
 			});
 		}
 	}
 
 	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
 
-	const finalResponse = await callLLM({
+	const finalResponse = await callLLMFn({
 		system,
 		prompt: `${buildTranscript(history)}\n\nUser: Maximum steps reached. Synthesize findings now.\n\nAssistant:`,
 		model: reasoningModel,

--- a/agents/legal-analyst/tests/agent.test.ts
+++ b/agents/legal-analyst/tests/agent.test.ts
@@ -5,12 +5,13 @@
  * and that the legal-analyst manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, LocalAgentRuntime } from "@shaleyeah/sdk";
+import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
 import {
 	createLegalAnalystEndpoint,
 	createLegalAnalystRuntime,
 	legalAnalystConfig,
 	legalAnalystManifest,
+	runLegalAnalystTask,
 } from "../src/agent/index.js";
 
 let passed = 0;
@@ -185,6 +186,47 @@ console.log("\n🏥 Testing health endpoint and standalone boot...");
 
 	const toolSchema = await endpoint.discoveryToolSchema("legal-analyst.analyze_legal_framework");
 	assert(toolSchema !== null, "Endpoint exposes tool schemas by name");
+}
+
+console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #428)...");
+{
+	const blockingConfig: typeof legalAnalystConfig = {
+		...legalAnalystConfig,
+		evals: {
+			...legalAnalystConfig.evals,
+			checks: { ...legalAnalystConfig.evals.checks, schema: "blocking" },
+		},
+	};
+	const blockingRuntime = new LocalAgentRuntime({
+		manifest: legalAnalystManifest,
+		config: blockingConfig,
+		handlers: Object.fromEntries(legalAnalystManifest.tools.map((t) => [t.name, async () => undefined])),
+	});
+	await blockingRuntime.initialize();
+
+	const llmCallCount: number[] = [];
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		llmCallCount.push(1);
+		if (llmCallCount.length === 1) {
+			return JSON.stringify({
+				action: "tool",
+				tool: "legal-analyst.analyze_legal_framework",
+				args: { jurisdiction: "Texas", operationType: "drilling", permitTypes: ["drilling"] },
+			});
+		}
+		return JSON.stringify({ action: "done", answer: "should not reach here" });
+	};
+
+	const result = await runLegalAnalystTask("Analyze legal framework", {
+		config: blockingConfig,
+		callLLM: mockLLM,
+		runtime: blockingRuntime,
+	});
+
+	assert(llmCallCount.length === 1, "executeLoop halts after permanent failure — LLM not called a second time");
+	assert(typeof result === "string" && result.length > 0, "Permanent failure returns non-empty error string");
+
+	await blockingRuntime.shutdown();
 }
 
 console.log("\n🛑 Testing invalid manifest fails early...");


### PR DESCRIPTION
## Summary

- Fixes `else` branch in `executeLoop` to return immediately on permanent failures (`!execResult.retryable`)
- Wires `callLLM?` injectable option through `runLegalAnalystTask` → `executeLoop`
- Adds throw guard when `standard-analysis` model route is missing
- Threads `callLLMFn` through both LLM call sites in `executeLoop`

Closes #428

## Test plan

- [x] 43/43 tests pass (`npx tsx tests/agent.test.ts`)
- [x] New permanent-halt test: blocking schema eval triggers 1 LLM call, loop halts, returns non-empty error string
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)