### PR TITLE
fix(#429): research-analyst Level 2 — permanent halt guard + injectable callLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`executeLoop` halts on permanent failures + injectable callLLM in research-analyst agent** (#429) — Added permanent halt guard (`!execResult.retryable`), `callLLM?` injectable option, and throw guard for missing `standard-analysis` model route. 2 new contract tests.
+
 - **`executeLoop` halts on permanent failures + executeWithRetry in quality-assurance agent** (#424) — Added `executeWithRetry` with 3-attempt exponential backoff and permanent halt guard (`!execResult.retryable`). Matching the geologist Level 2 reference. 2 new contract tests.
 
 - **`executeLoop` halts on permanent failures in economist agent** (#423) — `else` branch in `runEconomistTask`'s `executeLoop` previously logged a hint string and continued when `execResult.retryable === false`. Now returns immediately, matching the geologist Level 2 reference. Adds 2 contract tests verifying blocking eval halts the loop.

--- a/agents/research-analyst/CHANGELOG.md
+++ b/agents/research-analyst/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`executeLoop` halts on permanent failures + injectable callLLM** (#429) — Added permanent halt guard (`!execResult.retryable`), `callLLM?` injectable option, throw guard for missing `standard-analysis` model route, and threaded `callLLMFn` through both LLM call sites. Matching the geologist Level 2 reference. 2 new contract tests.
+
 ### Added
 - Full Tier 2 agent implementation for research/research-analyst pair (#369)
 - `researchAnalystManifest` and `researchAnalystConfig` — manifest + runtime config wired to `servers/research` at port 3008

--- a/agents/research-analyst/src/agent/index.ts
+++ b/agents/research-analyst/src/agent/index.ts
@@ -1,5 +1,11 @@
 import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
-import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import {
+	callLLM,
+	type LLMCallOptions,
+	LocalAgentEndpoint,
+	LocalAgentRuntime,
+	type StandaloneToolHandler,
+} from "@shaleyeah/sdk";
 import { callResearchTool } from "./research-client.js";
 
 export { callResearchTool };
@@ -219,6 +225,8 @@ export async function runResearchAnalystTask(
 		apiKey?: string;
 		runtime?: LocalAgentRuntime;
 		onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+		/** Inject a custom LLM function — used in tests to capture model routing without real API calls. */
+		callLLM?: (opts: LLMCallOptions) => Promise<string>;
 	} = {},
 ): Promise<string> {
 	const config = options.config ?? researchAnalystConfig;
@@ -232,7 +240,7 @@ export async function runResearchAnalystTask(
 	}
 
 	try {
-		return await executeLoop(goal, runtime, { ...options, config });
+		return await executeLoop(goal, runtime, { ...options, config, callLLMFn: options.callLLM ?? callLLM });
 	} finally {
 		if (ownedRuntime) await runtime.shutdown();
 	}
@@ -289,13 +297,23 @@ async function executeLoop(
 		config?: AgentRuntimeConfig;
 		apiKey?: string;
 		onApprovalRequired?: (challenge: HumanApprovalChallenge) => Promise<HumanApproval>;
+		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
 	// TODO (#395): Context Injection — before building the system prompt, read from
 	// memory.namespace = "research-analyst" to surface relevant prior task context.
 
 	const config = options.config ?? researchAnalystConfig;
-	const reasoningModel = config.modelRouting["standard-analysis"]?.model;
+	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	const standardAnalysisBinding = config.modelRouting["standard-analysis"];
+	if (!standardAnalysisBinding) {
+		throw new Error(
+			`[research-analyst] modelRouting is missing a "standard-analysis" entry. ` +
+				'Configure AgentRuntimeConfig.modelRouting["standard-analysis"] before calling runResearchAnalystTask.',
+		);
+	}
+	const reasoningModel = standardAnalysisBinding.model;
 
 	const toolDefs = researchAnalystManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
 
@@ -316,7 +334,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 	const MAX_STEPS = 8;
 
 	for (let step = 0; step < MAX_STEPS; step++) {
-		const response = await callLLM({
+		const response = await callLLMFn({
 			system,
 			prompt: `${buildTranscript(history)}\n\nAssistant:`,
 			model: reasoningModel,
@@ -362,14 +380,22 @@ If you cannot complete the task with the available tools, respond with {"action"
 				history.push({ role: "tool", content: `Error after approval for ${parsed.tool}: ${err}` });
 			}
 		} else {
-			const hint = execResult.retryable ? " (retryable — server may be temporarily unavailable)" : " (permanent)";
-			history.push({ role: "tool", content: `Error calling ${parsed.tool}: ${execResult.error}${hint}` });
+			// Permanent failure (blocking eval, scope rejection, unretryable error) — safety gate,
+			// do not continue the loop. The LLM cannot recover from a security or governance halt.
+			if (!execResult.retryable) {
+				return execResult.error ?? `Permanent failure calling ${parsed.tool}`;
+			}
+			// Transient failure — push to history so the LLM can reformulate and retry.
+			history.push({
+				role: "tool",
+				content: `Error calling ${parsed.tool}: ${execResult.error} (retryable — server may be temporarily unavailable)`,
+			});
 		}
 	}
 
 	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
 
-	const finalResponse = await callLLM({
+	const finalResponse = await callLLMFn({
 		system,
 		prompt: `${buildTranscript(history)}\n\nUser: Maximum steps reached. Synthesize findings now.\n\nAssistant:`,
 		model: reasoningModel,

--- a/agents/research-analyst/tests/agent.test.ts
+++ b/agents/research-analyst/tests/agent.test.ts
@@ -5,12 +5,13 @@
  * and that the research-analyst manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, LocalAgentRuntime } from "@shaleyeah/sdk";
+import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
 import {
 	createResearchAnalystEndpoint,
 	createResearchAnalystRuntime,
 	researchAnalystConfig,
 	researchAnalystManifest,
+	runResearchAnalystTask,
 } from "../src/agent/index.js";
 
 let passed = 0;
@@ -292,6 +293,47 @@ console.log("\n🔀 Testing model routing resolution...");
 		"standard-analysis model is a real model ID, not a placeholder",
 	);
 	assert(standardAnalysis?.provider === "anthropic", "standard-analysis provider is anthropic");
+}
+
+console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #429)...");
+{
+	const blockingConfig: typeof researchAnalystConfig = {
+		...researchAnalystConfig,
+		evals: {
+			...researchAnalystConfig.evals,
+			checks: { ...researchAnalystConfig.evals.checks, schema: "blocking" },
+		},
+	};
+	const blockingRuntime = new LocalAgentRuntime({
+		manifest: researchAnalystManifest,
+		config: blockingConfig,
+		handlers: Object.fromEntries(researchAnalystManifest.tools.map((t) => [t.name, async () => undefined])),
+	});
+	await blockingRuntime.initialize();
+
+	const llmCallCount: number[] = [];
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		llmCallCount.push(1);
+		if (llmCallCount.length === 1) {
+			return JSON.stringify({
+				action: "tool",
+				tool: "research-analyst.conduct_market_research",
+				args: { commodity: "crude oil", region: "Permian Basin", timeframe: "2025" },
+			});
+		}
+		return JSON.stringify({ action: "done", answer: "should not reach here" });
+	};
+
+	const result = await runResearchAnalystTask("Research oil market", {
+		config: blockingConfig,
+		callLLM: mockLLM,
+		runtime: blockingRuntime,
+	});
+
+	assert(llmCallCount.length === 1, "executeLoop halts after permanent failure — LLM not called a second time");
+	assert(typeof result === "string" && result.length > 0, "Permanent failure returns non-empty error string");
+
+	await blockingRuntime.shutdown();
 }
 
 console.log("\n🛑 Testing invalid manifest fails early...");


### PR DESCRIPTION
## Summary

- Fixes `else` branch in `executeLoop` to return immediately on permanent failures (`!execResult.retryable`)
- Wires `callLLM?` injectable option through `runResearchAnalystTask` → `executeLoop`
- Adds throw guard when `standard-analysis` model route is missing
- Threads `callLLMFn` through both LLM call sites

Closes #429

## Test plan

- [x] 36/36 tests pass (`npx tsx tests/agent.test.ts`)
- [x] New permanent-halt test: blocking schema eval triggers 1 LLM call, loop halts, returns non-empty error string
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)