### PR TITLE
feat(#395): context injection — ContextStore Phase 1 wired across all 14 agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Develop-only — not yet released to main.
 - **economist Tier 2 agent** (#364) — `runEconomistTask()` Layer 2 loop, MCP HTTP client; 34 tests.
 - **geologist foundation fixes** (#402–#407) — model routing wired, scope enforcement, blocking eval halt, `executeWithRetry`, `geologist.save_finding` write tool, `/health` endpoint on all 14 MCP servers.
 - **Level 2 batch — investment-chair, market-analyst, reporter-agent, reservoir-engineer, risk-analyst** (#439–#443) — all 5 remaining stub agents fully implemented: `runXxxTask` Layer 2 loop with `executeWithRetry` (3-attempt exponential backoff) + permanent halt guard (`!retryable` → return immediately); MCP HTTP clients wired to ports 3013/3007/3009/3004/3005; Arcade-compliant manifests + runtime configs; 265 tests total across all 5 agents (contract + MCP client suites).
+- **Context injection — `ContextStore` Phase 1** (#395) — new `sdk/src/context-store.ts` process-level singleton; all 14 agent `executeLoop` functions now read prior findings from their memory namespace before building the system prompt and write synthesized results on successful completion. Permanent failures (blocking evals, scope rejections) do not write. 28 new tests across all agents verify read-inject and write-after-run behavior.
 
 ### Changed
 

--- a/agents/development-planner/src/agent/index.ts
+++ b/agents/development-planner/src/agent/index.ts
@@ -1,5 +1,6 @@
 import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
 import {
+	ContextStore,
 	callLLM,
 	type LLMCallOptions,
 	LocalAgentEndpoint,
@@ -342,15 +343,19 @@ async function executeLoop(
 		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
-	// TODO (#395): Context Injection — read from memory.namespace before building system prompt.
-
 	const config = options.config ?? developmentPlannerConfig;
 	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	// Context Injection (#395): surface prior findings from this agent's namespace.
+	const namespace = config.memory?.namespace ?? "development-planner";
+	const priorContext = ContextStore.read(namespace);
 	const reasoningModel = config.modelRouting["standard-analysis"]?.model;
 
 	const toolDefs = developmentPlannerManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+	const priorContextSection = priorContext ? `\nPrior context from previous runs:\n${priorContext}\n` : "";
 
 	const system = `You are ${developmentPlannerManifest.persona.name}, ${developmentPlannerManifest.persona.role}.
+${priorContextSection}
 
 Available tools:
 ${toolDefs}
@@ -378,7 +383,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		const parsed = parseJson(response);
 		if (!parsed || parsed.action === "done" || !parsed.tool) {
-			return parsed?.answer ?? response;
+			const result = parsed?.answer ?? response;
+			ContextStore.write(namespace, result);
+			return result;
 		}
 
 		// TODO (#396): Async Job — detect long-running development analyses and poll for completion.
@@ -428,7 +435,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		}
 	}
 
-	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+	// Context Injection (#395): write synthesized findings so subsequent runs can surface them.
 
 	const finalResponse = await callLLMFn({
 		system,
@@ -437,7 +444,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 		apiKey: options.apiKey,
 	});
 
-	return parseJson(finalResponse)?.answer ?? finalResponse;
+	const finalResult = parseJson(finalResponse)?.answer ?? finalResponse;
+	ContextStore.write(namespace, finalResult);
+	return finalResult;
 }
 
 // ── CLI entrypoint ────────────────────────────────────────────────────────────

--- a/agents/development-planner/tests/agent.test.ts
+++ b/agents/development-planner/tests/agent.test.ts
@@ -5,7 +5,13 @@
  * and that the development-planner manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	AgentManifestSchema,
+	AgentRuntimeConfigSchema,
+	ContextStore,
+	type LLMCallOptions,
+	LocalAgentRuntime,
+} from "@shaleyeah/sdk";
 import {
 	createDevelopmentPlannerEndpoint,
 	createDevelopmentPlannerRuntime,
@@ -231,6 +237,51 @@ console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #425)
 	await blockingRuntime.shutdown();
 }
 
+console.log("\n🗂️  Testing context injection — prior context in prompt...");
+{
+	const ns = developmentPlannerManifest.memory?.namespace ?? "development-planner";
+	ContextStore.clear(ns);
+	ContextStore.write(ns, "Prior finding: test context seeded for Development Planner.");
+
+	let capturedSystem = "";
+	const mockLLM = async (opts: LLMCallOptions): Promise<string> => {
+		capturedSystem = opts.system ?? "";
+		return JSON.stringify({ action: "done", answer: "Analysis complete." });
+	};
+
+	const rt = createDevelopmentPlannerRuntime();
+	await rt.initialize();
+	await runDevelopmentPlannerTask("Analyze test data.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	assert(
+		capturedSystem.includes("Prior finding: test context seeded for Development Planner."),
+		"Prior context from namespace is injected into system prompt",
+	);
+	ContextStore.clear(ns);
+}
+
+console.log("\n🗂️  Testing context injection — findings written after run...");
+{
+	const ns = developmentPlannerManifest.memory?.namespace ?? "development-planner";
+	ContextStore.clear(ns);
+
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		return JSON.stringify({ action: "done", answer: "Development Planner analysis: test finding written to store." });
+	};
+
+	const rt = createDevelopmentPlannerRuntime();
+	await rt.initialize();
+	await runDevelopmentPlannerTask("Summarize the analysis.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	const stored = ContextStore.read(ns);
+	assert(
+		stored.includes("Development Planner analysis: test finding written to store."),
+		"Answer is written to context store after task completes",
+	);
+	ContextStore.clear(ns);
+}
 console.log("\n🛑 Testing invalid manifest fails early...");
 try {
 	new LocalAgentRuntime({

--- a/agents/drilling-engineer/src/agent/index.ts
+++ b/agents/drilling-engineer/src/agent/index.ts
@@ -1,5 +1,6 @@
 import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
 import {
+	ContextStore,
 	callLLM,
 	type LLMCallOptions,
 	LocalAgentEndpoint,
@@ -357,12 +358,17 @@ async function executeLoop(
 		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
-	// TODO (#395): Context Injection — read from memory.namespace before building system prompt.
-
 	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	// Context Injection (#395): surface prior findings from this agent's namespace.
+	const namespace = drillingEngineerConfig.memory?.namespace ?? "drilling-engineer";
+	const priorContext = ContextStore.read(namespace);
+
 	const toolDefs = drillingEngineerManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+	const priorContextSection = priorContext ? `\nPrior context from previous runs:\n${priorContext}\n` : "";
 
 	const system = `You are ${drillingEngineerManifest.persona.name}, ${drillingEngineerManifest.persona.role}.
+${priorContextSection}
 
 Available tools:
 ${toolDefs}
@@ -389,7 +395,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		const parsed = parseJson(response);
 		if (!parsed || parsed.action === "done" || !parsed.tool) {
-			return parsed?.answer ?? response;
+			const result = parsed?.answer ?? response;
+			ContextStore.write(namespace, result);
+			return result;
 		}
 
 		// TODO (#396): Async Job — detect asyncJob tools and poll instead of blocking.
@@ -441,7 +449,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		}
 	}
 
-	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+	// Context Injection (#395): write synthesized findings so subsequent runs can surface them.
 
 	const finalResponse = await callLLMFn({
 		system,
@@ -449,5 +457,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		apiKey: options.apiKey,
 	});
 
-	return parseJson(finalResponse)?.answer ?? finalResponse;
+	const finalResult = parseJson(finalResponse)?.answer ?? finalResponse;
+	ContextStore.write(namespace, finalResult);
+	return finalResult;
 }

--- a/agents/drilling-engineer/tests/agent.test.ts
+++ b/agents/drilling-engineer/tests/agent.test.ts
@@ -5,7 +5,13 @@
  * and that the drilling-engineer manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	AgentManifestSchema,
+	AgentRuntimeConfigSchema,
+	ContextStore,
+	type LLMCallOptions,
+	LocalAgentRuntime,
+} from "@shaleyeah/sdk";
 import {
 	createDrillingEngineerEndpoint,
 	createDrillingEngineerRuntime,
@@ -372,6 +378,51 @@ console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #426)
 	await blockingRuntime.shutdown();
 }
 
+console.log("\n🗂️  Testing context injection — prior context in prompt...");
+{
+	const ns = drillingEngineerManifest.memory?.namespace ?? "drilling-engineer";
+	ContextStore.clear(ns);
+	ContextStore.write(ns, "Prior finding: test context seeded for Drilling Engineer.");
+
+	let capturedSystem = "";
+	const mockLLM = async (opts: LLMCallOptions): Promise<string> => {
+		capturedSystem = opts.system ?? "";
+		return JSON.stringify({ action: "done", answer: "Analysis complete." });
+	};
+
+	const rt = createDrillingEngineerRuntime();
+	await rt.initialize();
+	await runDrillingEngineerTask("Analyze test data.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	assert(
+		capturedSystem.includes("Prior finding: test context seeded for Drilling Engineer."),
+		"Prior context from namespace is injected into system prompt",
+	);
+	ContextStore.clear(ns);
+}
+
+console.log("\n🗂️  Testing context injection — findings written after run...");
+{
+	const ns = drillingEngineerManifest.memory?.namespace ?? "drilling-engineer";
+	ContextStore.clear(ns);
+
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		return JSON.stringify({ action: "done", answer: "Drilling Engineer analysis: test finding written to store." });
+	};
+
+	const rt = createDrillingEngineerRuntime();
+	await rt.initialize();
+	await runDrillingEngineerTask("Summarize the analysis.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	const stored = ContextStore.read(ns);
+	assert(
+		stored.includes("Drilling Engineer analysis: test finding written to store."),
+		"Answer is written to context store after task completes",
+	);
+	ContextStore.clear(ns);
+}
 console.log("\n🛑 Testing invalid manifest fails early...");
 try {
 	new LocalAgentRuntime({

--- a/agents/economist/src/agent/index.ts
+++ b/agents/economist/src/agent/index.ts
@@ -5,7 +5,13 @@ import type {
 	HumanApprovalChallenge,
 	LLMCallOptions,
 } from "@shaleyeah/sdk";
-import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import {
+	ContextStore,
+	callLLM,
+	LocalAgentEndpoint,
+	LocalAgentRuntime,
+	type StandaloneToolHandler,
+} from "@shaleyeah/sdk";
 import { callEconobotTool } from "./econobot-client.js";
 
 export { callEconobotTool };
@@ -358,11 +364,12 @@ async function executeLoop(
 		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
-	// TODO (#395): Context Injection — before building the system prompt, read from
-	// memory.namespace = "economist" to surface relevant prior task context.
-
 	const config = options.config ?? economistConfig;
 	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	// Context Injection (#395): surface prior findings from this agent's namespace.
+	const namespace = config.memory?.namespace ?? "economist";
+	const priorContext = ContextStore.read(namespace);
 
 	// Resolve the model that drives the reasoning loop from the operator's routing table.
 	// The loop itself is always standard-analysis class — tool-level model requirements are
@@ -377,8 +384,10 @@ async function executeLoop(
 	const reasoningModel = standardAnalysisBinding.model;
 
 	const toolDefs = economistManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+	const priorContextSection = priorContext ? `\nPrior context from previous runs:\n${priorContext}\n` : "";
 
 	const system = `You are ${economistManifest.persona.name}, ${economistManifest.persona.role}.
+${priorContextSection}
 
 Available tools:
 ${toolDefs}
@@ -406,7 +415,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		const parsed = parseJson(response);
 		if (!parsed || parsed.action === "done" || !parsed.tool) {
-			return parsed?.answer ?? response;
+			const result = parsed?.answer ?? response;
+			ContextStore.write(namespace, result);
+			return result;
 		}
 
 		// TODO (#396): Async Job — detect long-running economic analyses and poll for completion.
@@ -456,7 +467,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		}
 	}
 
-	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+	// Context Injection (#395): write synthesized findings so subsequent runs can surface them.
 
 	const finalResponse = await callLLMFn({
 		system,
@@ -465,7 +476,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 		apiKey: options.apiKey,
 	});
 
-	return parseJson(finalResponse)?.answer ?? finalResponse;
+	const finalResult = parseJson(finalResponse)?.answer ?? finalResponse;
+	ContextStore.write(namespace, finalResult);
+	return finalResult;
 }
 
 // ── CLI entrypoint ────────────────────────────────────────────────────────────

--- a/agents/economist/tests/agent.test.ts
+++ b/agents/economist/tests/agent.test.ts
@@ -5,7 +5,13 @@
  * and that the economist manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	AgentManifestSchema,
+	AgentRuntimeConfigSchema,
+	ContextStore,
+	type LLMCallOptions,
+	LocalAgentRuntime,
+} from "@shaleyeah/sdk";
 import {
 	createEconomistEndpoint,
 	createEconomistRuntime,
@@ -228,6 +234,51 @@ console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #423)
 	await blockingRuntime.shutdown();
 }
 
+console.log("\n🗂️  Testing context injection — prior context in prompt...");
+{
+	const ns = economistManifest.memory?.namespace ?? "economist";
+	ContextStore.clear(ns);
+	ContextStore.write(ns, "Prior finding: test context seeded for Economist.");
+
+	let capturedSystem = "";
+	const mockLLM = async (opts: LLMCallOptions): Promise<string> => {
+		capturedSystem = opts.system ?? "";
+		return JSON.stringify({ action: "done", answer: "Analysis complete." });
+	};
+
+	const rt = createEconomistRuntime();
+	await rt.initialize();
+	await runEconomistTask("Analyze test data.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	assert(
+		capturedSystem.includes("Prior finding: test context seeded for Economist."),
+		"Prior context from namespace is injected into system prompt",
+	);
+	ContextStore.clear(ns);
+}
+
+console.log("\n🗂️  Testing context injection — findings written after run...");
+{
+	const ns = economistManifest.memory?.namespace ?? "economist";
+	ContextStore.clear(ns);
+
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		return JSON.stringify({ action: "done", answer: "Economist analysis: test finding written to store." });
+	};
+
+	const rt = createEconomistRuntime();
+	await rt.initialize();
+	await runEconomistTask("Summarize the analysis.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	const stored = ContextStore.read(ns);
+	assert(
+		stored.includes("Economist analysis: test finding written to store."),
+		"Answer is written to context store after task completes",
+	);
+	ContextStore.clear(ns);
+}
 console.log("\n🛑 Testing invalid manifest fails early...");
 {
 	try {

--- a/agents/geologist/src/agent/index.ts
+++ b/agents/geologist/src/agent/index.ts
@@ -5,7 +5,13 @@ import type {
 	HumanApprovalChallenge,
 	LLMCallOptions,
 } from "@shaleyeah/sdk";
-import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import {
+	ContextStore,
+	callLLM,
+	LocalAgentEndpoint,
+	LocalAgentRuntime,
+	type StandaloneToolHandler,
+} from "@shaleyeah/sdk";
 import { callGeowizTool } from "./geowiz-client.js";
 
 export { callGeowizTool };
@@ -511,12 +517,12 @@ async function executeLoop(
 		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
-	// TODO (#395): Context Injection — before building the system prompt, read from
-	// memory.namespace = "geologist" to surface relevant prior task context.
-	// Requires Supabase pgvector. Inject as an additional system prompt section.
-
 	const config = options.config ?? geologistConfig;
 	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	// Context Injection (#395): surface prior findings from this agent's namespace.
+	const namespace = config.memory?.namespace ?? "geologist";
+	const priorContext = ContextStore.read(namespace);
 
 	// Resolve the model that drives the reasoning loop from the operator's routing table.
 	// The loop itself is always standard-analysis class — tool-level model requirements are
@@ -531,9 +537,10 @@ async function executeLoop(
 	const reasoningModel = standardAnalysisBinding.model;
 
 	const toolDefs = geologistManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+	const priorContextSection = priorContext ? `\nPrior context from previous runs:\n${priorContext}\n` : "";
 
 	const system = `You are ${geologistManifest.persona.name}, ${geologistManifest.persona.role}.
-
+${priorContextSection}
 Available tools:
 ${toolDefs}
 
@@ -560,7 +567,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		const parsed = parseJson(response);
 		if (!parsed || parsed.action === "done" || !parsed.tool) {
-			return parsed?.answer ?? response;
+			const result = parsed?.answer ?? response;
+			ContextStore.write(namespace, result);
+			return result;
 		}
 
 		// TODO (#396): Async Job — if the tool manifest declares timeoutMs > threshold,
@@ -612,7 +621,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		}
 	}
 
-	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+	// Context Injection (#395): write synthesized findings so subsequent runs can surface them.
 
 	// Max steps reached — force a synthesis pass.
 	const finalResponse = await callLLMFn({
@@ -622,7 +631,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 		apiKey: options.apiKey,
 	});
 
-	return parseJson(finalResponse)?.answer ?? finalResponse;
+	const finalResult = parseJson(finalResponse)?.answer ?? finalResponse;
+	ContextStore.write(namespace, finalResult);
+	return finalResult;
 }
 
 // ── CLI entrypoint ────────────────────────────────────────────────────────────

--- a/agents/geologist/tests/agent.test.ts
+++ b/agents/geologist/tests/agent.test.ts
@@ -5,7 +5,13 @@
  * and that the geologist manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	AgentManifestSchema,
+	AgentRuntimeConfigSchema,
+	ContextStore,
+	type LLMCallOptions,
+	LocalAgentRuntime,
+} from "@shaleyeah/sdk";
 import {
 	createGeologistEndpoint,
 	createGeologistRuntime,
@@ -451,6 +457,52 @@ console.log("\n🔀 Testing model routing wired into callLLM (issue #402)...");
 		capturedModels[0] === expectedModel,
 		`executeLoop passes standard-analysis model (${expectedModel}) to callLLM via injectable option`,
 	);
+}
+
+console.log("\n🗂️  Testing context injection — prior context in prompt...");
+{
+	const ns = geologistManifest.memory?.namespace ?? "geologist";
+	ContextStore.clear(ns);
+	ContextStore.write(ns, "Prior finding: Wolfcamp A shows excellent porosity at 8,500 ft TVD.");
+
+	let capturedSystem = "";
+	const mockLLM = async (opts: LLMCallOptions): Promise<string> => {
+		capturedSystem = opts.system ?? "";
+		return JSON.stringify({ action: "done", answer: "Analysis complete." });
+	};
+
+	const rt = createGeologistRuntime();
+	await rt.initialize();
+	await runGeologistTask("Analyze formation data.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	assert(
+		capturedSystem.includes("Prior finding: Wolfcamp A"),
+		"Prior context from namespace is injected into system prompt",
+	);
+	ContextStore.clear(ns);
+}
+
+console.log("\n🗂️  Testing context injection — findings written after run...");
+{
+	const ns = geologistManifest.memory?.namespace ?? "geologist";
+	ContextStore.clear(ns);
+
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		return JSON.stringify({ action: "done", answer: "Formation analysis: strong Wolfcamp B signal." });
+	};
+
+	const rt = createGeologistRuntime();
+	await rt.initialize();
+	await runGeologistTask("Summarize the geological analysis.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	const stored = ContextStore.read(ns);
+	assert(
+		stored.includes("Formation analysis: strong Wolfcamp B signal."),
+		"Answer is written to context store after task completes",
+	);
+	ContextStore.clear(ns);
 }
 
 console.log("\n🛑 Testing invalid manifest fails early...");

--- a/agents/infrastructure-planner/src/agent/index.ts
+++ b/agents/infrastructure-planner/src/agent/index.ts
@@ -1,5 +1,6 @@
 import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
 import {
+	ContextStore,
 	callLLM,
 	type LLMCallOptions,
 	LocalAgentEndpoint,
@@ -365,6 +366,10 @@ async function executeLoop(
 	const config = options.config ?? infrastructurePlannerConfig;
 	const callLLMFn = options.callLLMFn ?? callLLM;
 
+	// Context Injection (#395): surface prior findings from this agent's namespace.
+	const namespace = config.memory?.namespace ?? "infrastructure-planner";
+	const priorContext = ContextStore.read(namespace);
+
 	const standardAnalysisBinding = config.modelRouting["standard-analysis"];
 	if (!standardAnalysisBinding) {
 		throw new Error(
@@ -375,8 +380,10 @@ async function executeLoop(
 	const reasoningModel = standardAnalysisBinding.model;
 
 	const toolDefs = infrastructurePlannerManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+	const priorContextSection = priorContext ? `\nPrior context from previous runs:\n${priorContext}\n` : "";
 
 	const system = `You are ${infrastructurePlannerManifest.persona.name}, ${infrastructurePlannerManifest.persona.role}.
+${priorContextSection}
 
 Available tools:
 ${toolDefs}
@@ -404,7 +411,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		const parsed = parseJson(response);
 		if (!parsed || parsed.action === "done" || !parsed.tool) {
-			return parsed?.answer ?? response;
+			const result = parsed?.answer ?? response;
+			ContextStore.write(namespace, result);
+			return result;
 		}
 
 		const execResult = await executeWithRetry(runtime, {
@@ -459,5 +468,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		apiKey: options.apiKey,
 	});
 
-	return parseJson(finalResponse)?.answer ?? finalResponse;
+	const finalResult = parseJson(finalResponse)?.answer ?? finalResponse;
+	ContextStore.write(namespace, finalResult);
+	return finalResult;
 }

--- a/agents/infrastructure-planner/tests/agent.test.ts
+++ b/agents/infrastructure-planner/tests/agent.test.ts
@@ -6,7 +6,13 @@
  * acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	AgentManifestSchema,
+	AgentRuntimeConfigSchema,
+	ContextStore,
+	type LLMCallOptions,
+	LocalAgentRuntime,
+} from "@shaleyeah/sdk";
 import {
 	createInfrastructurePlannerEndpoint,
 	createInfrastructurePlannerRuntime,
@@ -313,6 +319,54 @@ console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #427)
 	await blockingRuntime.shutdown();
 }
 
+console.log("\n🗂️  Testing context injection — prior context in prompt...");
+{
+	const ns = infrastructurePlannerManifest.memory?.namespace ?? "infrastructure-planner";
+	ContextStore.clear(ns);
+	ContextStore.write(ns, "Prior finding: test context seeded for Infrastructure Planner.");
+
+	let capturedSystem = "";
+	const mockLLM = async (opts: LLMCallOptions): Promise<string> => {
+		capturedSystem = opts.system ?? "";
+		return JSON.stringify({ action: "done", answer: "Analysis complete." });
+	};
+
+	const rt = createInfrastructurePlannerRuntime();
+	await rt.initialize();
+	await runInfrastructurePlannerTask("Analyze test data.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	assert(
+		capturedSystem.includes("Prior finding: test context seeded for Infrastructure Planner."),
+		"Prior context from namespace is injected into system prompt",
+	);
+	ContextStore.clear(ns);
+}
+
+console.log("\n🗂️  Testing context injection — findings written after run...");
+{
+	const ns = infrastructurePlannerManifest.memory?.namespace ?? "infrastructure-planner";
+	ContextStore.clear(ns);
+
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		return JSON.stringify({
+			action: "done",
+			answer: "Infrastructure Planner analysis: test finding written to store.",
+		});
+	};
+
+	const rt = createInfrastructurePlannerRuntime();
+	await rt.initialize();
+	await runInfrastructurePlannerTask("Summarize the analysis.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	const stored = ContextStore.read(ns);
+	assert(
+		stored.includes("Infrastructure Planner analysis: test finding written to store."),
+		"Answer is written to context store after task completes",
+	);
+	ContextStore.clear(ns);
+}
 console.log("\n🛑 Testing invalid manifest fails early...");
 {
 	try {

--- a/agents/investment-chair/src/agent/index.ts
+++ b/agents/investment-chair/src/agent/index.ts
@@ -5,7 +5,13 @@ import type {
 	HumanApprovalChallenge,
 	LLMCallOptions,
 } from "@shaleyeah/sdk";
-import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import {
+	ContextStore,
+	callLLM,
+	LocalAgentEndpoint,
+	LocalAgentRuntime,
+	type StandaloneToolHandler,
+} from "@shaleyeah/sdk";
 import { callDecisionTool } from "./decision-client.js";
 
 export { callDecisionTool };
@@ -346,11 +352,12 @@ async function executeLoop(
 		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
-	// TODO (#395): Context Injection — before building the system prompt, read from
-	// memory.namespace = "investment-chair" to surface relevant prior task context.
-
 	const config = options.config ?? investmentChairConfig;
 	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	// Context Injection (#395): surface prior findings from this agent's namespace.
+	const namespace = config.memory?.namespace ?? "investment-chair";
+	const priorContext = ContextStore.read(namespace);
 
 	// Resolve the model that drives the reasoning loop from the operator's routing table.
 	// The loop itself is always standard-analysis class — tool-level model requirements are
@@ -365,8 +372,10 @@ async function executeLoop(
 	const reasoningModel = standardAnalysisBinding.model;
 
 	const toolDefs = investmentChairManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+	const priorContextSection = priorContext ? `\nPrior context from previous runs:\n${priorContext}\n` : "";
 
 	const system = `You are ${investmentChairManifest.persona.name}, ${investmentChairManifest.persona.role}.
+${priorContextSection}
 
 Available tools:
 ${toolDefs}
@@ -394,7 +403,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		const parsed = parseJson(response);
 		if (!parsed || parsed.action === "done" || !parsed.tool) {
-			return parsed?.answer ?? response;
+			const result = parsed?.answer ?? response;
+			ContextStore.write(namespace, result);
+			return result;
 		}
 
 		// TODO (#396): Async Job — detect long-running decision analyses and poll for completion.
@@ -444,7 +455,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		}
 	}
 
-	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+	// Context Injection (#395): write synthesized findings so subsequent runs can surface them.
 
 	const finalResponse = await callLLMFn({
 		system,
@@ -453,7 +464,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 		apiKey: options.apiKey,
 	});
 
-	return parseJson(finalResponse)?.answer ?? finalResponse;
+	const finalResult = parseJson(finalResponse)?.answer ?? finalResponse;
+	ContextStore.write(namespace, finalResult);
+	return finalResult;
 }
 
 // ── CLI entrypoint ────────────────────────────────────────────────────────────

--- a/agents/investment-chair/tests/agent.test.ts
+++ b/agents/investment-chair/tests/agent.test.ts
@@ -5,7 +5,13 @@
  * and that the investment-chair manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	AgentManifestSchema,
+	AgentRuntimeConfigSchema,
+	ContextStore,
+	type LLMCallOptions,
+	LocalAgentRuntime,
+} from "@shaleyeah/sdk";
 import {
 	createInvestmentChairEndpoint,
 	createInvestmentChairRuntime,
@@ -224,6 +230,51 @@ console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #439)
 	await blockingRuntime.shutdown();
 }
 
+console.log("\n🗂️  Testing context injection — prior context in prompt...");
+{
+	const ns = investmentChairManifest.memory?.namespace ?? "investment-chair";
+	ContextStore.clear(ns);
+	ContextStore.write(ns, "Prior finding: test context seeded for Investment Chair.");
+
+	let capturedSystem = "";
+	const mockLLM = async (opts: LLMCallOptions): Promise<string> => {
+		capturedSystem = opts.system ?? "";
+		return JSON.stringify({ action: "done", answer: "Analysis complete." });
+	};
+
+	const rt = createInvestmentChairRuntime();
+	await rt.initialize();
+	await runInvestmentChairTask("Analyze test data.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	assert(
+		capturedSystem.includes("Prior finding: test context seeded for Investment Chair."),
+		"Prior context from namespace is injected into system prompt",
+	);
+	ContextStore.clear(ns);
+}
+
+console.log("\n🗂️  Testing context injection — findings written after run...");
+{
+	const ns = investmentChairManifest.memory?.namespace ?? "investment-chair";
+	ContextStore.clear(ns);
+
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		return JSON.stringify({ action: "done", answer: "Investment Chair analysis: test finding written to store." });
+	};
+
+	const rt = createInvestmentChairRuntime();
+	await rt.initialize();
+	await runInvestmentChairTask("Summarize the analysis.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	const stored = ContextStore.read(ns);
+	assert(
+		stored.includes("Investment Chair analysis: test finding written to store."),
+		"Answer is written to context store after task completes",
+	);
+	ContextStore.clear(ns);
+}
 console.log("\n🛑 Testing invalid manifest fails early...");
 {
 	try {

--- a/agents/legal-analyst/src/agent/index.ts
+++ b/agents/legal-analyst/src/agent/index.ts
@@ -1,5 +1,6 @@
 import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
 import {
+	ContextStore,
 	callLLM,
 	type LLMCallOptions,
 	LocalAgentEndpoint,
@@ -351,10 +352,12 @@ async function executeLoop(
 		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
-	// TODO (#395): Context Injection — read from memory.namespace before building system prompt.
-
 	const config = options.config ?? legalAnalystConfig;
 	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	// Context Injection (#395): surface prior findings from this agent's namespace.
+	const namespace = config.memory?.namespace ?? "legal-analyst";
+	const priorContext = ContextStore.read(namespace);
 
 	const standardAnalysisBinding = config.modelRouting["standard-analysis"];
 	if (!standardAnalysisBinding) {
@@ -366,8 +369,10 @@ async function executeLoop(
 	const reasoningModel = standardAnalysisBinding.model;
 
 	const toolDefs = legalAnalystManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+	const priorContextSection = priorContext ? `\nPrior context from previous runs:\n${priorContext}\n` : "";
 
 	const system = `You are ${legalAnalystManifest.persona.name}, ${legalAnalystManifest.persona.role}.
+${priorContextSection}
 
 Available tools:
 ${toolDefs}
@@ -395,7 +400,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		const parsed = parseJson(response);
 		if (!parsed || parsed.action === "done" || !parsed.tool) {
-			return parsed?.answer ?? response;
+			const result = parsed?.answer ?? response;
+			ContextStore.write(namespace, result);
+			return result;
 		}
 
 		// TODO (#396): Async Job — detect long-running legal analyses and poll for completion.
@@ -445,7 +452,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		}
 	}
 
-	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+	// Context Injection (#395): write synthesized findings so subsequent runs can surface them.
 
 	const finalResponse = await callLLMFn({
 		system,
@@ -454,7 +461,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 		apiKey: options.apiKey,
 	});
 
-	return parseJson(finalResponse)?.answer ?? finalResponse;
+	const finalResult = parseJson(finalResponse)?.answer ?? finalResponse;
+	ContextStore.write(namespace, finalResult);
+	return finalResult;
 }
 
 // ── CLI entrypoint ────────────────────────────────────────────────────────────

--- a/agents/legal-analyst/tests/agent.test.ts
+++ b/agents/legal-analyst/tests/agent.test.ts
@@ -5,7 +5,13 @@
  * and that the legal-analyst manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	AgentManifestSchema,
+	AgentRuntimeConfigSchema,
+	ContextStore,
+	type LLMCallOptions,
+	LocalAgentRuntime,
+} from "@shaleyeah/sdk";
 import {
 	createLegalAnalystEndpoint,
 	createLegalAnalystRuntime,
@@ -229,6 +235,51 @@ console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #428)
 	await blockingRuntime.shutdown();
 }
 
+console.log("\n🗂️  Testing context injection — prior context in prompt...");
+{
+	const ns = legalAnalystManifest.memory?.namespace ?? "legal-analyst";
+	ContextStore.clear(ns);
+	ContextStore.write(ns, "Prior finding: test context seeded for Legal Analyst.");
+
+	let capturedSystem = "";
+	const mockLLM = async (opts: LLMCallOptions): Promise<string> => {
+		capturedSystem = opts.system ?? "";
+		return JSON.stringify({ action: "done", answer: "Analysis complete." });
+	};
+
+	const rt = createLegalAnalystRuntime();
+	await rt.initialize();
+	await runLegalAnalystTask("Analyze test data.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	assert(
+		capturedSystem.includes("Prior finding: test context seeded for Legal Analyst."),
+		"Prior context from namespace is injected into system prompt",
+	);
+	ContextStore.clear(ns);
+}
+
+console.log("\n🗂️  Testing context injection — findings written after run...");
+{
+	const ns = legalAnalystManifest.memory?.namespace ?? "legal-analyst";
+	ContextStore.clear(ns);
+
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		return JSON.stringify({ action: "done", answer: "Legal Analyst analysis: test finding written to store." });
+	};
+
+	const rt = createLegalAnalystRuntime();
+	await rt.initialize();
+	await runLegalAnalystTask("Summarize the analysis.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	const stored = ContextStore.read(ns);
+	assert(
+		stored.includes("Legal Analyst analysis: test finding written to store."),
+		"Answer is written to context store after task completes",
+	);
+	ContextStore.clear(ns);
+}
 console.log("\n🛑 Testing invalid manifest fails early...");
 try {
 	new LocalAgentRuntime({

--- a/agents/market-analyst/src/agent/index.ts
+++ b/agents/market-analyst/src/agent/index.ts
@@ -5,7 +5,13 @@ import type {
 	HumanApprovalChallenge,
 	LLMCallOptions,
 } from "@shaleyeah/sdk";
-import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import {
+	ContextStore,
+	callLLM,
+	LocalAgentEndpoint,
+	LocalAgentRuntime,
+	type StandaloneToolHandler,
+} from "@shaleyeah/sdk";
 import { callMarketTool } from "./market-client.js";
 
 export { callMarketTool };
@@ -301,11 +307,12 @@ async function executeLoop(
 		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
-	// TODO (#395): Context Injection — before building the system prompt, read from
-	// memory.namespace = "market-analyst" to surface relevant prior task context.
-
 	const config = options.config ?? marketAnalystConfig;
 	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	// Context Injection (#395): surface prior findings from this agent's namespace.
+	const namespace = config.memory?.namespace ?? "market-analyst";
+	const priorContext = ContextStore.read(namespace);
 
 	const standardAnalysisBinding = config.modelRouting["standard-analysis"];
 	if (!standardAnalysisBinding) {
@@ -317,8 +324,10 @@ async function executeLoop(
 	const reasoningModel = standardAnalysisBinding.model;
 
 	const toolDefs = marketAnalystManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+	const priorContextSection = priorContext ? `\nPrior context from previous runs:\n${priorContext}\n` : "";
 
 	const system = `You are ${marketAnalystManifest.persona.name}, ${marketAnalystManifest.persona.role}.
+${priorContextSection}
 
 Available tools:
 ${toolDefs}
@@ -346,7 +355,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		const parsed = parseJson(response);
 		if (!parsed || parsed.action === "done" || !parsed.tool) {
-			return parsed?.answer ?? response;
+			const result = parsed?.answer ?? response;
+			ContextStore.write(namespace, result);
+			return result;
 		}
 
 		// TODO (#396): Async Job — detect long-running market analyses and poll for completion.
@@ -396,7 +407,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		}
 	}
 
-	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+	// Context Injection (#395): write synthesized findings so subsequent runs can surface them.
 
 	const finalResponse = await callLLMFn({
 		system,
@@ -405,7 +416,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 		apiKey: options.apiKey,
 	});
 
-	return parseJson(finalResponse)?.answer ?? finalResponse;
+	const finalResult = parseJson(finalResponse)?.answer ?? finalResponse;
+	ContextStore.write(namespace, finalResult);
+	return finalResult;
 }
 
 // ── CLI entrypoint ────────────────────────────────────────────────────────────

--- a/agents/market-analyst/tests/agent.test.ts
+++ b/agents/market-analyst/tests/agent.test.ts
@@ -5,7 +5,13 @@
  * and that the market-analyst manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	AgentManifestSchema,
+	AgentRuntimeConfigSchema,
+	ContextStore,
+	type LLMCallOptions,
+	LocalAgentRuntime,
+} from "@shaleyeah/sdk";
 import {
 	createMarketAnalystEndpoint,
 	createMarketAnalystRuntime,
@@ -218,6 +224,51 @@ console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #440)
 	await blockingRuntime.shutdown();
 }
 
+console.log("\n🗂️  Testing context injection — prior context in prompt...");
+{
+	const ns = marketAnalystManifest.memory?.namespace ?? "market-analyst";
+	ContextStore.clear(ns);
+	ContextStore.write(ns, "Prior finding: test context seeded for Market Analyst.");
+
+	let capturedSystem = "";
+	const mockLLM = async (opts: LLMCallOptions): Promise<string> => {
+		capturedSystem = opts.system ?? "";
+		return JSON.stringify({ action: "done", answer: "Analysis complete." });
+	};
+
+	const rt = createMarketAnalystRuntime();
+	await rt.initialize();
+	await runMarketAnalystTask("Analyze test data.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	assert(
+		capturedSystem.includes("Prior finding: test context seeded for Market Analyst."),
+		"Prior context from namespace is injected into system prompt",
+	);
+	ContextStore.clear(ns);
+}
+
+console.log("\n🗂️  Testing context injection — findings written after run...");
+{
+	const ns = marketAnalystManifest.memory?.namespace ?? "market-analyst";
+	ContextStore.clear(ns);
+
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		return JSON.stringify({ action: "done", answer: "Market Analyst analysis: test finding written to store." });
+	};
+
+	const rt = createMarketAnalystRuntime();
+	await rt.initialize();
+	await runMarketAnalystTask("Summarize the analysis.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	const stored = ContextStore.read(ns);
+	assert(
+		stored.includes("Market Analyst analysis: test finding written to store."),
+		"Answer is written to context store after task completes",
+	);
+	ContextStore.clear(ns);
+}
 console.log("\n🛑 Testing invalid manifest fails early...");
 {
 	try {

--- a/agents/quality-assurance/src/agent/index.ts
+++ b/agents/quality-assurance/src/agent/index.ts
@@ -5,7 +5,13 @@ import type {
 	HumanApprovalChallenge,
 	LLMCallOptions,
 } from "@shaleyeah/sdk";
-import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import {
+	ContextStore,
+	callLLM,
+	LocalAgentEndpoint,
+	LocalAgentRuntime,
+	type StandaloneToolHandler,
+} from "@shaleyeah/sdk";
 import { callQAServerTool } from "./qa-server-client.js";
 
 export { callQAServerTool };
@@ -319,11 +325,12 @@ async function executeLoop(
 		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
-	// TODO (#395): Context Injection — before building the system prompt, read from
-	// memory.namespace = "quality-assurance" to surface relevant prior task context.
-
 	const config = options.config ?? qaAssuranceConfig;
 	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	// Context Injection (#395): surface prior findings from this agent's namespace.
+	const namespace = config.memory?.namespace ?? "quality-assurance";
+	const priorContext = ContextStore.read(namespace);
 
 	// Resolve the model that drives the reasoning loop from the operator's routing table.
 	// The loop itself is always standard-analysis class — tool-level model requirements are
@@ -338,8 +345,10 @@ async function executeLoop(
 	const reasoningModel = standardAnalysisBinding.model;
 
 	const toolDefs = qaAssuranceManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+	const priorContextSection = priorContext ? `\nPrior context from previous runs:\n${priorContext}\n` : "";
 
 	const system = `You are ${qaAssuranceManifest.persona.name}, ${qaAssuranceManifest.persona.role}.
+${priorContextSection}
 
 Available tools:
 ${toolDefs}
@@ -367,7 +376,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		const parsed = parseJson(response);
 		if (!parsed || parsed.action === "done" || !parsed.tool) {
-			return parsed?.answer ?? response;
+			const result = parsed?.answer ?? response;
+			ContextStore.write(namespace, result);
+			return result;
 		}
 
 		// TODO (#396): Async Job — detect long-running test suites and poll for completion.
@@ -417,7 +428,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		}
 	}
 
-	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+	// Context Injection (#395): write synthesized findings so subsequent runs can surface them.
 
 	const finalResponse = await callLLMFn({
 		system,
@@ -426,5 +437,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		apiKey: options.apiKey,
 	});
 
-	return parseJson(finalResponse)?.answer ?? finalResponse;
+	const finalResult = parseJson(finalResponse)?.answer ?? finalResponse;
+	ContextStore.write(namespace, finalResult);
+	return finalResult;
 }

--- a/agents/quality-assurance/tests/agent.test.ts
+++ b/agents/quality-assurance/tests/agent.test.ts
@@ -5,7 +5,13 @@
  * and that the quality-assurance manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	AgentManifestSchema,
+	AgentRuntimeConfigSchema,
+	ContextStore,
+	type LLMCallOptions,
+	LocalAgentRuntime,
+} from "@shaleyeah/sdk";
 import {
 	createQAAssuranceEndpoint,
 	createQAAssuranceRuntime,
@@ -293,6 +299,51 @@ console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #424)
 	await blockingRuntime.shutdown();
 }
 
+console.log("\n🗂️  Testing context injection — prior context in prompt...");
+{
+	const ns = qaAssuranceManifest.memory?.namespace ?? "quality-assurance";
+	ContextStore.clear(ns);
+	ContextStore.write(ns, "Prior finding: test context seeded for QA Assurance.");
+
+	let capturedSystem = "";
+	const mockLLM = async (opts: LLMCallOptions): Promise<string> => {
+		capturedSystem = opts.system ?? "";
+		return JSON.stringify({ action: "done", answer: "Analysis complete." });
+	};
+
+	const rt = createQAAssuranceRuntime();
+	await rt.initialize();
+	await runQAAssuranceTask("Analyze test data.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	assert(
+		capturedSystem.includes("Prior finding: test context seeded for QA Assurance."),
+		"Prior context from namespace is injected into system prompt",
+	);
+	ContextStore.clear(ns);
+}
+
+console.log("\n🗂️  Testing context injection — findings written after run...");
+{
+	const ns = qaAssuranceManifest.memory?.namespace ?? "quality-assurance";
+	ContextStore.clear(ns);
+
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		return JSON.stringify({ action: "done", answer: "QA Assurance analysis: test finding written to store." });
+	};
+
+	const rt = createQAAssuranceRuntime();
+	await rt.initialize();
+	await runQAAssuranceTask("Summarize the analysis.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	const stored = ContextStore.read(ns);
+	assert(
+		stored.includes("QA Assurance analysis: test finding written to store."),
+		"Answer is written to context store after task completes",
+	);
+	ContextStore.clear(ns);
+}
 console.log("\n🛑 Testing invalid manifest fails early...");
 {
 	try {

--- a/agents/reporter-agent/src/agent/index.ts
+++ b/agents/reporter-agent/src/agent/index.ts
@@ -5,7 +5,13 @@ import type {
 	HumanApprovalChallenge,
 	LLMCallOptions,
 } from "@shaleyeah/sdk";
-import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import {
+	ContextStore,
+	callLLM,
+	LocalAgentEndpoint,
+	LocalAgentRuntime,
+	type StandaloneToolHandler,
+} from "@shaleyeah/sdk";
 import { callReporterTool } from "./reporter-client.js";
 
 export { callReporterTool };
@@ -335,11 +341,12 @@ async function executeLoop(
 		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
-	// TODO (#395): Context Injection — before building the system prompt, read from
-	// memory.namespace = "reporter-agent" to surface relevant prior task context.
-
 	const config = options.config ?? reporterAgentConfig;
 	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	// Context Injection (#395): surface prior findings from this agent's namespace.
+	const namespace = config.memory?.namespace ?? "reporter-agent";
+	const priorContext = ContextStore.read(namespace);
 
 	const standardAnalysisBinding = config.modelRouting["standard-analysis"];
 	if (!standardAnalysisBinding) {
@@ -351,8 +358,10 @@ async function executeLoop(
 	const reasoningModel = standardAnalysisBinding.model;
 
 	const toolDefs = reporterAgentManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+	const priorContextSection = priorContext ? `\nPrior context from previous runs:\n${priorContext}\n` : "";
 
 	const system = `You are ${reporterAgentManifest.persona.name}, ${reporterAgentManifest.persona.role}.
+${priorContextSection}
 
 Available tools:
 ${toolDefs}
@@ -380,7 +389,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		const parsed = parseJson(response);
 		if (!parsed || parsed.action === "done" || !parsed.tool) {
-			return parsed?.answer ?? response;
+			const result = parsed?.answer ?? response;
+			ContextStore.write(namespace, result);
+			return result;
 		}
 
 		// TODO (#396): Async Job — detect long-running report generation and poll for completion.
@@ -430,7 +441,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		}
 	}
 
-	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+	// Context Injection (#395): write synthesized findings so subsequent runs can surface them.
 
 	const finalResponse = await callLLMFn({
 		system,
@@ -439,7 +450,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 		apiKey: options.apiKey,
 	});
 
-	return parseJson(finalResponse)?.answer ?? finalResponse;
+	const finalResult = parseJson(finalResponse)?.answer ?? finalResponse;
+	ContextStore.write(namespace, finalResult);
+	return finalResult;
 }
 
 // ── CLI entrypoint ────────────────────────────────────────────────────────────

--- a/agents/reporter-agent/tests/agent.test.ts
+++ b/agents/reporter-agent/tests/agent.test.ts
@@ -5,7 +5,13 @@
  * and that the reporter-agent manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	AgentManifestSchema,
+	AgentRuntimeConfigSchema,
+	ContextStore,
+	type LLMCallOptions,
+	LocalAgentRuntime,
+} from "@shaleyeah/sdk";
 import {
 	createReporterAgentEndpoint,
 	createReporterAgentRuntime,
@@ -225,6 +231,51 @@ console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #441)
 	await blockingRuntime.shutdown();
 }
 
+console.log("\n🗂️  Testing context injection — prior context in prompt...");
+{
+	const ns = reporterAgentManifest.memory?.namespace ?? "reporter-agent";
+	ContextStore.clear(ns);
+	ContextStore.write(ns, "Prior finding: test context seeded for Reporter Agent.");
+
+	let capturedSystem = "";
+	const mockLLM = async (opts: LLMCallOptions): Promise<string> => {
+		capturedSystem = opts.system ?? "";
+		return JSON.stringify({ action: "done", answer: "Analysis complete." });
+	};
+
+	const rt = createReporterAgentRuntime();
+	await rt.initialize();
+	await runReporterAgentTask("Analyze test data.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	assert(
+		capturedSystem.includes("Prior finding: test context seeded for Reporter Agent."),
+		"Prior context from namespace is injected into system prompt",
+	);
+	ContextStore.clear(ns);
+}
+
+console.log("\n🗂️  Testing context injection — findings written after run...");
+{
+	const ns = reporterAgentManifest.memory?.namespace ?? "reporter-agent";
+	ContextStore.clear(ns);
+
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		return JSON.stringify({ action: "done", answer: "Reporter Agent analysis: test finding written to store." });
+	};
+
+	const rt = createReporterAgentRuntime();
+	await rt.initialize();
+	await runReporterAgentTask("Summarize the analysis.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	const stored = ContextStore.read(ns);
+	assert(
+		stored.includes("Reporter Agent analysis: test finding written to store."),
+		"Answer is written to context store after task completes",
+	);
+	ContextStore.clear(ns);
+}
 console.log("\n🛑 Testing invalid manifest fails early...");
 {
 	try {

--- a/agents/research-analyst/src/agent/index.ts
+++ b/agents/research-analyst/src/agent/index.ts
@@ -1,5 +1,6 @@
 import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
 import {
+	ContextStore,
 	callLLM,
 	type LLMCallOptions,
 	LocalAgentEndpoint,
@@ -300,11 +301,12 @@ async function executeLoop(
 		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
-	// TODO (#395): Context Injection — before building the system prompt, read from
-	// memory.namespace = "research-analyst" to surface relevant prior task context.
-
 	const config = options.config ?? researchAnalystConfig;
 	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	// Context Injection (#395): surface prior findings from this agent's namespace.
+	const namespace = config.memory?.namespace ?? "research-analyst";
+	const priorContext = ContextStore.read(namespace);
 
 	const standardAnalysisBinding = config.modelRouting["standard-analysis"];
 	if (!standardAnalysisBinding) {
@@ -316,8 +318,10 @@ async function executeLoop(
 	const reasoningModel = standardAnalysisBinding.model;
 
 	const toolDefs = researchAnalystManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+	const priorContextSection = priorContext ? `\nPrior context from previous runs:\n${priorContext}\n` : "";
 
 	const system = `You are ${researchAnalystManifest.persona.name}, ${researchAnalystManifest.persona.role}.
+${priorContextSection}
 
 Available tools:
 ${toolDefs}
@@ -345,7 +349,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		const parsed = parseJson(response);
 		if (!parsed || parsed.action === "done" || !parsed.tool) {
-			return parsed?.answer ?? response;
+			const result = parsed?.answer ?? response;
+			ContextStore.write(namespace, result);
+			return result;
 		}
 
 		// TODO (#396): Async Job — detect asyncJob tools and poll instead of blocking.
@@ -393,7 +399,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		}
 	}
 
-	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+	// Context Injection (#395): write synthesized findings so subsequent runs can surface them.
 
 	const finalResponse = await callLLMFn({
 		system,
@@ -402,7 +408,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 		apiKey: options.apiKey,
 	});
 
-	return parseJson(finalResponse)?.answer ?? finalResponse;
+	const finalResult = parseJson(finalResponse)?.answer ?? finalResponse;
+	ContextStore.write(namespace, finalResult);
+	return finalResult;
 }
 
 // ── CLI entrypoint ────────────────────────────────────────────────────────────

--- a/agents/research-analyst/tests/agent.test.ts
+++ b/agents/research-analyst/tests/agent.test.ts
@@ -5,7 +5,13 @@
  * and that the research-analyst manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	AgentManifestSchema,
+	AgentRuntimeConfigSchema,
+	ContextStore,
+	type LLMCallOptions,
+	LocalAgentRuntime,
+} from "@shaleyeah/sdk";
 import {
 	createResearchAnalystEndpoint,
 	createResearchAnalystRuntime,
@@ -336,6 +342,51 @@ console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #429)
 	await blockingRuntime.shutdown();
 }
 
+console.log("\n🗂️  Testing context injection — prior context in prompt...");
+{
+	const ns = researchAnalystManifest.memory?.namespace ?? "research-analyst";
+	ContextStore.clear(ns);
+	ContextStore.write(ns, "Prior finding: test context seeded for Research Analyst.");
+
+	let capturedSystem = "";
+	const mockLLM = async (opts: LLMCallOptions): Promise<string> => {
+		capturedSystem = opts.system ?? "";
+		return JSON.stringify({ action: "done", answer: "Analysis complete." });
+	};
+
+	const rt = createResearchAnalystRuntime();
+	await rt.initialize();
+	await runResearchAnalystTask("Analyze test data.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	assert(
+		capturedSystem.includes("Prior finding: test context seeded for Research Analyst."),
+		"Prior context from namespace is injected into system prompt",
+	);
+	ContextStore.clear(ns);
+}
+
+console.log("\n🗂️  Testing context injection — findings written after run...");
+{
+	const ns = researchAnalystManifest.memory?.namespace ?? "research-analyst";
+	ContextStore.clear(ns);
+
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		return JSON.stringify({ action: "done", answer: "Research Analyst analysis: test finding written to store." });
+	};
+
+	const rt = createResearchAnalystRuntime();
+	await rt.initialize();
+	await runResearchAnalystTask("Summarize the analysis.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	const stored = ContextStore.read(ns);
+	assert(
+		stored.includes("Research Analyst analysis: test finding written to store."),
+		"Answer is written to context store after task completes",
+	);
+	ContextStore.clear(ns);
+}
 console.log("\n🛑 Testing invalid manifest fails early...");
 {
 	try {

--- a/agents/reservoir-engineer/src/agent/index.ts
+++ b/agents/reservoir-engineer/src/agent/index.ts
@@ -5,7 +5,13 @@ import type {
 	HumanApprovalChallenge,
 	LLMCallOptions,
 } from "@shaleyeah/sdk";
-import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import {
+	ContextStore,
+	callLLM,
+	LocalAgentEndpoint,
+	LocalAgentRuntime,
+	type StandaloneToolHandler,
+} from "@shaleyeah/sdk";
 import { callCurveSmithTool } from "./curve-smith-client.js";
 
 export { callCurveSmithTool };
@@ -374,11 +380,12 @@ async function executeLoop(
 		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
-	// TODO (#395): Context Injection — before building the system prompt, read from
-	// memory.namespace = "reservoir-engineer" to surface relevant prior task context.
-
 	const config = options.config ?? reservoirEngineerConfig;
 	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	// Context Injection (#395): surface prior findings from this agent's namespace.
+	const namespace = config.memory?.namespace ?? "reservoir-engineer";
+	const priorContext = ContextStore.read(namespace);
 
 	const standardAnalysisBinding = config.modelRouting["standard-analysis"];
 	if (!standardAnalysisBinding) {
@@ -390,8 +397,10 @@ async function executeLoop(
 	const reasoningModel = standardAnalysisBinding.model;
 
 	const toolDefs = reservoirEngineerManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+	const priorContextSection = priorContext ? `\nPrior context from previous runs:\n${priorContext}\n` : "";
 
 	const system = `You are ${reservoirEngineerManifest.persona.name}, ${reservoirEngineerManifest.persona.role}.
+${priorContextSection}
 
 Available tools:
 ${toolDefs}
@@ -419,7 +428,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		const parsed = parseJson(response);
 		if (!parsed || parsed.action === "done" || !parsed.tool) {
-			return parsed?.answer ?? response;
+			const result = parsed?.answer ?? response;
+			ContextStore.write(namespace, result);
+			return result;
 		}
 
 		// TODO (#396): Async Job — detect long-running EUR calculations and poll for completion.
@@ -469,7 +480,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		}
 	}
 
-	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+	// Context Injection (#395): write synthesized findings so subsequent runs can surface them.
 
 	const finalResponse = await callLLMFn({
 		system,
@@ -478,7 +489,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 		apiKey: options.apiKey,
 	});
 
-	return parseJson(finalResponse)?.answer ?? finalResponse;
+	const finalResult = parseJson(finalResponse)?.answer ?? finalResponse;
+	ContextStore.write(namespace, finalResult);
+	return finalResult;
 }
 
 // ── CLI entrypoint ────────────────────────────────────────────────────────────

--- a/agents/reservoir-engineer/tests/agent.test.ts
+++ b/agents/reservoir-engineer/tests/agent.test.ts
@@ -5,7 +5,13 @@
  * and that the reservoir-engineer manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	AgentManifestSchema,
+	AgentRuntimeConfigSchema,
+	ContextStore,
+	type LLMCallOptions,
+	LocalAgentRuntime,
+} from "@shaleyeah/sdk";
 import {
 	createReservoirEngineerEndpoint,
 	createReservoirEngineerRuntime,
@@ -228,6 +234,51 @@ console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #442)
 	await blockingRuntime.shutdown();
 }
 
+console.log("\n🗂️  Testing context injection — prior context in prompt...");
+{
+	const ns = reservoirEngineerManifest.memory?.namespace ?? "reservoir-engineer";
+	ContextStore.clear(ns);
+	ContextStore.write(ns, "Prior finding: test context seeded for Reservoir Engineer.");
+
+	let capturedSystem = "";
+	const mockLLM = async (opts: LLMCallOptions): Promise<string> => {
+		capturedSystem = opts.system ?? "";
+		return JSON.stringify({ action: "done", answer: "Analysis complete." });
+	};
+
+	const rt = createReservoirEngineerRuntime();
+	await rt.initialize();
+	await runReservoirEngineerTask("Analyze test data.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	assert(
+		capturedSystem.includes("Prior finding: test context seeded for Reservoir Engineer."),
+		"Prior context from namespace is injected into system prompt",
+	);
+	ContextStore.clear(ns);
+}
+
+console.log("\n🗂️  Testing context injection — findings written after run...");
+{
+	const ns = reservoirEngineerManifest.memory?.namespace ?? "reservoir-engineer";
+	ContextStore.clear(ns);
+
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		return JSON.stringify({ action: "done", answer: "Reservoir Engineer analysis: test finding written to store." });
+	};
+
+	const rt = createReservoirEngineerRuntime();
+	await rt.initialize();
+	await runReservoirEngineerTask("Summarize the analysis.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	const stored = ContextStore.read(ns);
+	assert(
+		stored.includes("Reservoir Engineer analysis: test finding written to store."),
+		"Answer is written to context store after task completes",
+	);
+	ContextStore.clear(ns);
+}
 console.log("\n🛑 Testing invalid manifest fails early...");
 {
 	try {

--- a/agents/risk-analyst/src/agent/index.ts
+++ b/agents/risk-analyst/src/agent/index.ts
@@ -5,7 +5,13 @@ import type {
 	HumanApprovalChallenge,
 	LLMCallOptions,
 } from "@shaleyeah/sdk";
-import { callLLM, LocalAgentEndpoint, LocalAgentRuntime, type StandaloneToolHandler } from "@shaleyeah/sdk";
+import {
+	ContextStore,
+	callLLM,
+	LocalAgentEndpoint,
+	LocalAgentRuntime,
+	type StandaloneToolHandler,
+} from "@shaleyeah/sdk";
 import { callRiskAnalysisTool } from "./risk-analysis-client.js";
 
 export { callRiskAnalysisTool };
@@ -334,11 +340,12 @@ async function executeLoop(
 		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
-	// TODO (#395): Context Injection — before building the system prompt, read from
-	// memory.namespace = "risk-analyst" to surface relevant prior task context.
-
 	const config = options.config ?? riskAnalystConfig;
 	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	// Context Injection (#395): surface prior findings from this agent's namespace.
+	const namespace = config.memory?.namespace ?? "risk-analyst";
+	const priorContext = ContextStore.read(namespace);
 
 	const standardAnalysisBinding = config.modelRouting["standard-analysis"];
 	if (!standardAnalysisBinding) {
@@ -350,8 +357,10 @@ async function executeLoop(
 	const reasoningModel = standardAnalysisBinding.model;
 
 	const toolDefs = riskAnalystManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+	const priorContextSection = priorContext ? `\nPrior context from previous runs:\n${priorContext}\n` : "";
 
 	const system = `You are ${riskAnalystManifest.persona.name}, ${riskAnalystManifest.persona.role}.
+${priorContextSection}
 
 Available tools:
 ${toolDefs}
@@ -379,7 +388,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		const parsed = parseJson(response);
 		if (!parsed || parsed.action === "done" || !parsed.tool) {
-			return parsed?.answer ?? response;
+			const result = parsed?.answer ?? response;
+			ContextStore.write(namespace, result);
+			return result;
 		}
 
 		// TODO (#396): Async Job — detect long-running Monte Carlo simulations and poll for completion.
@@ -429,7 +440,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		}
 	}
 
-	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+	// Context Injection (#395): write synthesized findings so subsequent runs can surface them.
 
 	const finalResponse = await callLLMFn({
 		system,
@@ -438,7 +449,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 		apiKey: options.apiKey,
 	});
 
-	return parseJson(finalResponse)?.answer ?? finalResponse;
+	const finalResult = parseJson(finalResponse)?.answer ?? finalResponse;
+	ContextStore.write(namespace, finalResult);
+	return finalResult;
 }
 
 // ── CLI entrypoint ────────────────────────────────────────────────────────────

--- a/agents/risk-analyst/tests/agent.test.ts
+++ b/agents/risk-analyst/tests/agent.test.ts
@@ -5,7 +5,13 @@
  * and that the risk-analyst manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	AgentManifestSchema,
+	AgentRuntimeConfigSchema,
+	ContextStore,
+	type LLMCallOptions,
+	LocalAgentRuntime,
+} from "@shaleyeah/sdk";
 import {
 	createRiskAnalystEndpoint,
 	createRiskAnalystRuntime,
@@ -218,6 +224,51 @@ console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #443)
 	await blockingRuntime.shutdown();
 }
 
+console.log("\n🗂️  Testing context injection — prior context in prompt...");
+{
+	const ns = riskAnalystManifest.memory?.namespace ?? "risk-analyst";
+	ContextStore.clear(ns);
+	ContextStore.write(ns, "Prior finding: test context seeded for Risk Analyst.");
+
+	let capturedSystem = "";
+	const mockLLM = async (opts: LLMCallOptions): Promise<string> => {
+		capturedSystem = opts.system ?? "";
+		return JSON.stringify({ action: "done", answer: "Analysis complete." });
+	};
+
+	const rt = createRiskAnalystRuntime();
+	await rt.initialize();
+	await runRiskAnalystTask("Analyze test data.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	assert(
+		capturedSystem.includes("Prior finding: test context seeded for Risk Analyst."),
+		"Prior context from namespace is injected into system prompt",
+	);
+	ContextStore.clear(ns);
+}
+
+console.log("\n🗂️  Testing context injection — findings written after run...");
+{
+	const ns = riskAnalystManifest.memory?.namespace ?? "risk-analyst";
+	ContextStore.clear(ns);
+
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		return JSON.stringify({ action: "done", answer: "Risk Analyst analysis: test finding written to store." });
+	};
+
+	const rt = createRiskAnalystRuntime();
+	await rt.initialize();
+	await runRiskAnalystTask("Summarize the analysis.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	const stored = ContextStore.read(ns);
+	assert(
+		stored.includes("Risk Analyst analysis: test finding written to store."),
+		"Answer is written to context store after task completes",
+	);
+	ContextStore.clear(ns);
+}
 console.log("\n🛑 Testing invalid manifest fails early...");
 {
 	try {

--- a/agents/title-analyst/src/agent/index.ts
+++ b/agents/title-analyst/src/agent/index.ts
@@ -1,5 +1,6 @@
 import type { AgentManifest, AgentRuntimeConfig, HumanApproval, HumanApprovalChallenge } from "@shaleyeah/sdk";
 import {
+	ContextStore,
 	callLLM,
 	type LLMCallOptions,
 	LocalAgentEndpoint,
@@ -355,10 +356,12 @@ async function executeLoop(
 		callLLMFn?: (opts: LLMCallOptions) => Promise<string>;
 	},
 ): Promise<string> {
-	// TODO (#395): Context Injection — read from memory.namespace before building system prompt.
-
 	const config = options.config ?? titleAnalystConfig;
 	const callLLMFn = options.callLLMFn ?? callLLM;
+
+	// Context Injection (#395): surface prior findings from this agent's namespace.
+	const namespace = config.memory?.namespace ?? "title-analyst";
+	const priorContext = ContextStore.read(namespace);
 
 	const standardAnalysisBinding = config.modelRouting["standard-analysis"];
 	if (!standardAnalysisBinding) {
@@ -370,8 +373,10 @@ async function executeLoop(
 	const reasoningModel = standardAnalysisBinding.model;
 
 	const toolDefs = titleAnalystManifest.tools.map((t) => `  ${t.name}: ${t.description}`).join("\n");
+	const priorContextSection = priorContext ? `\nPrior context from previous runs:\n${priorContext}\n` : "";
 
 	const system = `You are ${titleAnalystManifest.persona.name}, ${titleAnalystManifest.persona.role}.
+${priorContextSection}
 
 Available tools:
 ${toolDefs}
@@ -399,7 +404,9 @@ If you cannot complete the task with the available tools, respond with {"action"
 
 		const parsed = parseJson(response);
 		if (!parsed || parsed.action === "done" || !parsed.tool) {
-			return parsed?.answer ?? response;
+			const result = parsed?.answer ?? response;
+			ContextStore.write(namespace, result);
+			return result;
 		}
 
 		// TODO (#396): Async Job — detect asyncJob tools and poll instead of blocking.
@@ -451,7 +458,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		}
 	}
 
-	// TODO (#395): Context Injection — write key findings to memory.namespace before returning.
+	// Context Injection (#395): write synthesized findings so subsequent runs can surface them.
 
 	const finalResponse = await callLLMFn({
 		system,
@@ -460,5 +467,7 @@ If you cannot complete the task with the available tools, respond with {"action"
 		apiKey: options.apiKey,
 	});
 
-	return parseJson(finalResponse)?.answer ?? finalResponse;
+	const finalResult = parseJson(finalResponse)?.answer ?? finalResponse;
+	ContextStore.write(namespace, finalResult);
+	return finalResult;
 }

--- a/agents/title-analyst/tests/agent.test.ts
+++ b/agents/title-analyst/tests/agent.test.ts
@@ -5,7 +5,13 @@
  * and that the title-analyst manifest satisfies all Arcade acceptance criteria.
  */
 
-import { AgentManifestSchema, AgentRuntimeConfigSchema, type LLMCallOptions, LocalAgentRuntime } from "@shaleyeah/sdk";
+import {
+	AgentManifestSchema,
+	AgentRuntimeConfigSchema,
+	ContextStore,
+	type LLMCallOptions,
+	LocalAgentRuntime,
+} from "@shaleyeah/sdk";
 import {
 	createTitleAnalystEndpoint,
 	createTitleAnalystRuntime,
@@ -313,6 +319,51 @@ console.log("\n🔴 Testing permanent halt on non-retryable failure (issue #430)
 	await blockingRuntime.shutdown();
 }
 
+console.log("\n🗂️  Testing context injection — prior context in prompt...");
+{
+	const ns = titleAnalystManifest.memory?.namespace ?? "title-analyst";
+	ContextStore.clear(ns);
+	ContextStore.write(ns, "Prior finding: test context seeded for Title Analyst.");
+
+	let capturedSystem = "";
+	const mockLLM = async (opts: LLMCallOptions): Promise<string> => {
+		capturedSystem = opts.system ?? "";
+		return JSON.stringify({ action: "done", answer: "Analysis complete." });
+	};
+
+	const rt = createTitleAnalystRuntime();
+	await rt.initialize();
+	await runTitleAnalystTask("Analyze test data.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	assert(
+		capturedSystem.includes("Prior finding: test context seeded for Title Analyst."),
+		"Prior context from namespace is injected into system prompt",
+	);
+	ContextStore.clear(ns);
+}
+
+console.log("\n🗂️  Testing context injection — findings written after run...");
+{
+	const ns = titleAnalystManifest.memory?.namespace ?? "title-analyst";
+	ContextStore.clear(ns);
+
+	const mockLLM = async (_opts: LLMCallOptions): Promise<string> => {
+		return JSON.stringify({ action: "done", answer: "Title Analyst analysis: test finding written to store." });
+	};
+
+	const rt = createTitleAnalystRuntime();
+	await rt.initialize();
+	await runTitleAnalystTask("Summarize the analysis.", { runtime: rt, callLLM: mockLLM });
+	await rt.shutdown();
+
+	const stored = ContextStore.read(ns);
+	assert(
+		stored.includes("Title Analyst analysis: test finding written to store."),
+		"Answer is written to context store after task completes",
+	);
+	ContextStore.clear(ns);
+}
 console.log("\n🛑 Testing invalid manifest fails early...");
 {
 	try {

--- a/sdk/src/context-store.ts
+++ b/sdk/src/context-store.ts
@@ -1,0 +1,38 @@
+/**
+ * In-process context store for agent memory namespaces (Phase 1 of #395).
+ *
+ * Each agent writes synthesized findings to its namespace after each run and reads
+ * prior findings before building the system prompt. This is a process-level singleton —
+ * findings persist across runXxxTask() calls within the same process but are lost on
+ * restart. Phase 2 will swap this backing store for Supabase pgvector (#405).
+ *
+ * Namespaces are isolated: geologist cannot read economist findings.
+ */
+const store = new Map<string, string[]>();
+
+export const ContextStore = {
+	/** Returns concatenated prior findings, or empty string if none. */
+	read(namespace: string): string {
+		const entries = store.get(namespace);
+		if (!entries || entries.length === 0) return "";
+		return entries.join("\n\n");
+	},
+
+	/** Appends a finding to the namespace. No-ops on blank strings. */
+	write(namespace: string, finding: string): void {
+		if (!finding.trim()) return;
+		const entries = store.get(namespace) ?? [];
+		entries.push(finding.trim());
+		store.set(namespace, entries);
+	},
+
+	/** Clears one namespace — used in tests to prevent cross-test leakage. */
+	clear(namespace: string): void {
+		store.delete(namespace);
+	},
+
+	/** Clears all namespaces — used in test suite teardown. */
+	clearAll(): void {
+		store.clear();
+	},
+};

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./canonical-model.js";
+export * from "./context-store.js";
 export * from "./contracts.js";
 export * from "./errors.js";
 export * from "./file-detector.js";


### PR DESCRIPTION
## Summary

- New `sdk/src/context-store.ts`: process-level `Map<string, string[]>` singleton. Each namespace is isolated — `geologist` cannot read `economist` findings
- All 14 agent `executeLoop` functions now read prior findings from `config.memory?.namespace` before building the system prompt, and write synthesized results on the "done" and max-steps paths
- Permanent failures (`!retryable`: blocking evals, scope rejections) do **not** write to the store — only valid answers count as findings
- 28 new tests (2 per agent): prior-context-in-prompt and findings-written-after-run, each using injectable `callLLM` with explicit `ContextStore.clear()` before/after to prevent cross-test leakage
- Phase 2 (persistent Supabase pgvector backing store) remains blocked on #405

## Test plan

- [x] `pnpm turbo build` — 31/31 packages
- [x] `pnpm turbo lint` — 30/30 packages (biome import sort applied across all 14 agents + sdk)
- [x] `pnpm turbo test` — 31/31 suites pass, 28 new context injection tests green
- [x] Anti-pattern scan: no direct `@anthropic-ai/sdk` imports, no `Math.random()` outside Monte Carlo samplers, no `z.any()` outside sdk exemptions
- [x] Diff review: process-restart loss is intentional Phase 1 behavior (documented in module header); namespace isolation by unique key prevents collision

closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)