### PR TITLE
Ignore Claude symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ gitleaks-report.json
 # Personal agent-runtime tooling — every contributor picks their own tool and
 # workflow; none of it is checked in. Covers config dirs, entrypoint MD files,
 # and local state for Claude Code, Antigravity, Codex, Cursor, Windsurf, etc.
+.claude
 .claude/
 .claude.json
 .agents/


### PR DESCRIPTION
## Summary
- Add `.claude` to `.gitignore` so the new `.claude -> .agents` symlink is ignored.
- Keep the existing `.claude/` pattern for the old directory shape.

## Verification
- `git check-ignore -v .claude .agents AGENTS.md`
- `git status --short --ignored .claude .agents AGENTS.md .gitignore`
- pre-commit hook passed during commit.